### PR TITLE
feat: redesign product page with improved structure

### DIFF
--- a/src/app/product/page.tsx
+++ b/src/app/product/page.tsx
@@ -1,0 +1,738 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Play,
+  MessageSquare,
+  Brain,
+  Users,
+  ArrowRight,
+  Clock,
+  Zap,
+  CheckCircle,
+  FileText,
+  Video,
+  BarChart3,
+  Shield,
+  Lock,
+  Globe,
+  ChevronDown,
+} from "lucide-react";
+import Navigation from "@/components/landing/Navigation";
+import Footer from "@/components/landing/Footer";
+import { SectionReveal, StaggerReveal } from "@/components/landing/SectionReveal";
+import { CurveDivider } from "@/components/landing/SectionDivider";
+import { useState } from "react";
+
+export default function ProductPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Navigation currentPage="product" />
+
+      {/* Hero Section - Product Demo Focus */}
+      <section className="relative pt-8 sm:pt-12 lg:pt-16 pb-28 sm:pb-32 overflow-hidden">
+        {/* Subtle background */}
+        <div className="absolute inset-0 overflow-hidden">
+          <div className="absolute top-1/4 right-0 w-[600px] h-[600px] bg-gradient-to-bl from-blue-100/50 via-transparent to-transparent rounded-full blur-3xl" />
+        </div>
+
+        <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-6 relative z-10">
+          <SectionReveal className="text-center max-w-4xl mx-auto mb-12">
+            <div className="text-sm font-semibold text-blue-600 mb-4 uppercase tracking-wide">
+              See It In Action
+            </div>
+            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold leading-tight mb-6 text-gray-900">
+              Watch a candidate complete a real simulation
+            </h1>
+            <p className="text-lg sm:text-xl text-gray-600 max-w-3xl mx-auto">
+              This is what your hiring team sees after a candidate finishes. Real
+              conversations. Real work. Real signal.
+            </p>
+          </SectionReveal>
+
+          {/* Product Demo Video Placeholder */}
+          <SectionReveal delay="delay-200" className="max-w-5xl mx-auto">
+            <div className="bg-white rounded-2xl shadow-2xl border border-gray-200 p-3 sm:p-4">
+              <div className="aspect-video bg-gradient-to-br from-gray-900 to-gray-800 rounded-xl flex items-center justify-center relative overflow-hidden group cursor-pointer">
+                {/* Play button overlay */}
+                <div className="absolute inset-0 bg-black/20 group-hover:bg-black/30 transition-colors" />
+                <div className="relative z-10 flex flex-col items-center">
+                  <div className="w-20 h-20 bg-white/90 rounded-full flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform">
+                    <Play className="w-8 h-8 text-blue-600 ml-1" />
+                  </div>
+                  <p className="text-white/90 mt-4 font-medium">
+                    Watch 2-minute product demo
+                  </p>
+                </div>
+                {/* Placeholder label */}
+                <div className="absolute bottom-4 right-4 bg-black/50 text-white/70 text-xs px-3 py-1 rounded">
+                  Video: Full product walkthrough showing simulation creation → candidate
+                  experience → review dashboard
+                </div>
+              </div>
+            </div>
+          </SectionReveal>
+        </div>
+        <CurveDivider fillColor="fill-slate-50" />
+      </section>
+
+      {/* The Simulation Experience - Deep Dive */}
+      <section className="relative py-20 sm:py-24 bg-slate-50">
+        <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="text-center mb-16">
+            <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
+              A realistic first day—not algorithm puzzles
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Candidates experience what the job actually feels like. You see how they
+              actually work.
+            </p>
+          </SectionReveal>
+
+          {/* Timeline/Journey View */}
+          <div className="max-w-5xl mx-auto">
+            <StaggerReveal className="space-y-6" staggerMs={150}>
+              {/* Stage 1: Kickoff */}
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-center">
+                <div className="bg-white rounded-xl p-6 border border-gray-200 shadow-sm">
+                  <div className="flex items-start gap-4">
+                    <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                      <span className="text-xl font-bold text-blue-600">1</span>
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-bold text-gray-900 mb-2">
+                        Manager kickoff call
+                      </h3>
+                      <p className="text-gray-600 mb-4">
+                        Candidate joins a voice call with their AI &ldquo;manager&rdquo; who explains
+                        the project context, team dynamics, and expectations. Just like a
+                        real first day.
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        <span className="text-xs bg-blue-50 text-blue-700 px-2 py-1 rounded">
+                          Voice conversation
+                        </span>
+                        <span className="text-xs bg-blue-50 text-blue-700 px-2 py-1 rounded">
+                          ~5 minutes
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-white rounded-xl border border-gray-200 p-3">
+                  <div className="aspect-[16/10] bg-gradient-to-br from-blue-50 to-gray-50 rounded-lg flex items-center justify-center">
+                    <div className="text-center text-gray-400">
+                      <div className="w-12 h-12 bg-blue-100 rounded-lg mx-auto mb-2 flex items-center justify-center">
+                        <span className="text-xl">📞</span>
+                      </div>
+                      <p className="text-xs font-medium">
+                        Screenshot: Manager voice call interface with transcript
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Stage 2: Requirements */}
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-center">
+                <div className="bg-white rounded-xl border border-gray-200 p-3 order-2 lg:order-1">
+                  <div className="aspect-[16/10] bg-gradient-to-br from-purple-50 to-gray-50 rounded-lg flex items-center justify-center">
+                    <div className="text-center text-gray-400">
+                      <div className="w-12 h-12 bg-purple-100 rounded-lg mx-auto mb-2 flex items-center justify-center">
+                        <span className="text-xl">💬</span>
+                      </div>
+                      <p className="text-xs font-medium">
+                        Screenshot: Chat with PM showing requirement clarification
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-white rounded-xl p-6 border border-gray-200 shadow-sm order-1 lg:order-2">
+                  <div className="flex items-start gap-4">
+                    <div className="w-12 h-12 bg-purple-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                      <span className="text-xl font-bold text-purple-600">2</span>
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-bold text-gray-900 mb-2">
+                        Gather requirements
+                      </h3>
+                      <p className="text-gray-600 mb-4">
+                        They chat with the PM, designer, or other stakeholders to clarify
+                        the task. Great candidates ask smart questions. Others dive in
+                        blind. You&apos;ll see the difference.
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        <span className="text-xs bg-purple-50 text-purple-700 px-2 py-1 rounded">
+                          Text chat
+                        </span>
+                        <span className="text-xs bg-purple-50 text-purple-700 px-2 py-1 rounded">
+                          Multiple stakeholders
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Stage 3: Do the work */}
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-center">
+                <div className="bg-white rounded-xl p-6 border border-gray-200 shadow-sm">
+                  <div className="flex items-start gap-4">
+                    <div className="w-12 h-12 bg-emerald-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                      <span className="text-xl font-bold text-emerald-600">3</span>
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-bold text-gray-900 mb-2">
+                        Do the actual work
+                      </h3>
+                      <p className="text-gray-600 mb-4">
+                        Build the feature, analyze the data, create the roadmap—whatever
+                        the role requires. Screen is recorded. AI tools are encouraged. We
+                        want to see how they really work.
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        <span className="text-xs bg-emerald-50 text-emerald-700 px-2 py-1 rounded">
+                          Screen recorded
+                        </span>
+                        <span className="text-xs bg-emerald-50 text-emerald-700 px-2 py-1 rounded">
+                          AI tools allowed
+                        </span>
+                        <span className="text-xs bg-emerald-50 text-emerald-700 px-2 py-1 rounded">
+                          ~20-30 minutes
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-white rounded-xl border border-gray-200 p-3">
+                  <div className="aspect-[16/10] bg-gradient-to-br from-emerald-50 to-gray-50 rounded-lg flex items-center justify-center">
+                    <div className="text-center text-gray-400">
+                      <div className="w-12 h-12 bg-emerald-100 rounded-lg mx-auto mb-2 flex items-center justify-center">
+                        <span className="text-xl">💻</span>
+                      </div>
+                      <p className="text-xs font-medium">
+                        Screenshot: Candidate working with screen recording indicator
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Stage 4: Present & Defend */}
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-center">
+                <div className="bg-white rounded-xl border border-gray-200 p-3 order-2 lg:order-1">
+                  <div className="aspect-[16/10] bg-gradient-to-br from-amber-50 to-gray-50 rounded-lg flex items-center justify-center">
+                    <div className="text-center text-gray-400">
+                      <div className="w-12 h-12 bg-amber-100 rounded-lg mx-auto mb-2 flex items-center justify-center">
+                        <span className="text-xl">🎤</span>
+                      </div>
+                      <p className="text-xs font-medium">
+                        Screenshot: PR defense call with challenging questions
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-white rounded-xl p-6 border border-gray-200 shadow-sm order-1 lg:order-2">
+                  <div className="flex items-start gap-4">
+                    <div className="w-12 h-12 bg-amber-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                      <span className="text-xl font-bold text-amber-600">4</span>
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-bold text-gray-900 mb-2">
+                        Present and defend
+                      </h3>
+                      <p className="text-gray-600 mb-4">
+                        Submit the work and face questions. The AI pushes back on
+                        decisions. Do they defend good ideas? Accept valid criticism? Fold
+                        at the first sign of disagreement?
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        <span className="text-xs bg-amber-50 text-amber-700 px-2 py-1 rounded">
+                          Voice call
+                        </span>
+                        <span className="text-xs bg-amber-50 text-amber-700 px-2 py-1 rounded">
+                          Challenging questions
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </StaggerReveal>
+          </div>
+        </div>
+        <CurveDivider fillColor="fill-white" />
+      </section>
+
+      {/* What You Get - Concrete Deliverables */}
+      <section className="relative py-20 sm:py-24 bg-white">
+        <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="text-center mb-16">
+            <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
+              Everything you need to make the decision
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Not just a score. Actual evidence of how they work.
+            </p>
+          </SectionReveal>
+
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
+            <StaggerReveal className="contents" staggerMs={100}>
+              {/* Deliverable 1: Scorecard */}
+              <Card className="border-2 border-gray-100 hover:border-blue-200 hover:shadow-lg transition-all duration-300">
+                <CardContent className="p-0">
+                  <div className="aspect-[4/3] bg-gradient-to-br from-blue-50 to-gray-50 rounded-t-lg flex items-center justify-center border-b">
+                    <div className="text-center text-gray-400">
+                      <div className="w-12 h-12 bg-blue-100 rounded-lg mx-auto mb-2 flex items-center justify-center">
+                        <BarChart3 className="w-6 h-6 text-blue-600" />
+                      </div>
+                      <p className="text-xs font-medium px-4">
+                        Screenshot: Structured scorecard with dimension ratings
+                      </p>
+                    </div>
+                  </div>
+                  <div className="p-6">
+                    <h3 className="text-lg font-bold text-gray-900 mb-2">
+                      Structured Scorecard
+                    </h3>
+                    <p className="text-gray-600 text-sm">
+                      AI-generated ratings across key dimensions: communication,
+                      problem-solving, execution quality, AI usage, and handling feedback.
+                      Compare candidates consistently.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Deliverable 2: Transcripts */}
+              <Card className="border-2 border-gray-100 hover:border-blue-200 hover:shadow-lg transition-all duration-300">
+                <CardContent className="p-0">
+                  <div className="aspect-[4/3] bg-gradient-to-br from-purple-50 to-gray-50 rounded-t-lg flex items-center justify-center border-b">
+                    <div className="text-center text-gray-400">
+                      <div className="w-12 h-12 bg-purple-100 rounded-lg mx-auto mb-2 flex items-center justify-center">
+                        <MessageSquare className="w-6 h-6 text-purple-600" />
+                      </div>
+                      <p className="text-xs font-medium px-4">
+                        Screenshot: Conversation transcript with highlights
+                      </p>
+                    </div>
+                  </div>
+                  <div className="p-6">
+                    <h3 className="text-lg font-bold text-gray-900 mb-2">
+                      Full Transcripts
+                    </h3>
+                    <p className="text-gray-600 text-sm">
+                      Every conversation with stakeholders. See what questions they asked,
+                      how they clarified requirements, and how they handled pushback.
+                      AI-highlighted key moments.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Deliverable 3: Recording */}
+              <Card className="border-2 border-gray-100 hover:border-blue-200 hover:shadow-lg transition-all duration-300">
+                <CardContent className="p-0">
+                  <div className="aspect-[4/3] bg-gradient-to-br from-emerald-50 to-gray-50 rounded-t-lg flex items-center justify-center border-b">
+                    <div className="text-center text-gray-400">
+                      <div className="w-12 h-12 bg-emerald-100 rounded-lg mx-auto mb-2 flex items-center justify-center">
+                        <Video className="w-6 h-6 text-emerald-600" />
+                      </div>
+                      <p className="text-xs font-medium px-4">
+                        Screenshot: Screen recording player with timeline
+                      </p>
+                    </div>
+                  </div>
+                  <div className="p-6">
+                    <h3 className="text-lg font-bold text-gray-900 mb-2">
+                      Screen Recording
+                    </h3>
+                    <p className="text-gray-600 text-sm">
+                      Watch their entire process if you want. See how they used AI tools,
+                      how they debugged, how they approached the problem. Skip to key
+                      moments or watch it all.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            </StaggerReveal>
+          </div>
+
+          {/* Additional deliverables row */}
+          <SectionReveal className="mt-8 max-w-6xl mx-auto">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div className="flex items-center gap-3 bg-gray-50 rounded-lg p-4">
+                <FileText className="w-5 h-5 text-blue-600" />
+                <div>
+                  <p className="font-medium text-gray-900">Work Artifacts</p>
+                  <p className="text-sm text-gray-500">Code, docs, or deliverables</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 bg-gray-50 rounded-lg p-4">
+                <Clock className="w-5 h-5 text-blue-600" />
+                <div>
+                  <p className="font-medium text-gray-900">Time Analysis</p>
+                  <p className="text-sm text-gray-500">How they allocated their time</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 bg-gray-50 rounded-lg p-4">
+                <Users className="w-5 h-5 text-blue-600" />
+                <div>
+                  <p className="font-medium text-gray-900">Side-by-Side Compare</p>
+                  <p className="text-sm text-gray-500">Stack rank your candidates</p>
+                </div>
+              </div>
+            </div>
+          </SectionReveal>
+        </div>
+        <CurveDivider fillColor="fill-slate-50" />
+      </section>
+
+      {/* Signals Grid - What You Learn */}
+      <section className="relative py-20 sm:py-24 bg-slate-50">
+        <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="text-center mb-16">
+            <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
+              Signals you can&apos;t get from algorithm tests
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Coding tests tell you if someone can code. We tell you if they can do the
+              job.
+            </p>
+          </SectionReveal>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto">
+            <StaggerReveal className="contents" staggerMs={75}>
+              <Card className="border-2 border-gray-100 hover:border-blue-200 transition-colors">
+                <CardContent className="p-6">
+                  <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mb-4">
+                    <MessageSquare className="w-6 h-6 text-blue-600" />
+                  </div>
+                  <h3 className="text-lg font-bold text-gray-900 mb-2">
+                    Requirement gathering
+                  </h3>
+                  <p className="text-gray-600 text-sm">
+                    Do they ask the right questions? How do they navigate ambiguity with
+                    stakeholders? Do they make assumptions or clarify?
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card className="border-2 border-gray-100 hover:border-blue-200 transition-colors">
+                <CardContent className="p-6">
+                  <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mb-4">
+                    <Brain className="w-6 h-6 text-blue-600" />
+                  </div>
+                  <h3 className="text-lg font-bold text-gray-900 mb-2">AI tool usage</h3>
+                  <p className="text-gray-600 text-sm">
+                    Do they use AI thoughtfully or blindly copy-paste? Do they verify
+                    output? Can they explain what AI generated vs. their own work?
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card className="border-2 border-gray-100 hover:border-blue-200 transition-colors">
+                <CardContent className="p-6">
+                  <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mb-4">
+                    <Zap className="w-6 h-6 text-blue-600" />
+                  </div>
+                  <h3 className="text-lg font-bold text-gray-900 mb-2">
+                    Execution quality
+                  </h3>
+                  <p className="text-gray-600 text-sm">
+                    Technical skill and problem-solving visible in real work. Not memorized
+                    solutions or LeetCode patterns.
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card className="border-2 border-gray-100 hover:border-blue-200 transition-colors">
+                <CardContent className="p-6">
+                  <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mb-4">
+                    <Users className="w-6 h-6 text-blue-600" />
+                  </div>
+                  <h3 className="text-lg font-bold text-gray-900 mb-2">Communication</h3>
+                  <p className="text-gray-600 text-sm">
+                    Can they explain their work clearly? Translate technical concepts to
+                    business impact? Write professionally?
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card className="border-2 border-gray-100 hover:border-blue-200 transition-colors">
+                <CardContent className="p-6">
+                  <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mb-4">
+                    <CheckCircle className="w-6 h-6 text-blue-600" />
+                  </div>
+                  <h3 className="text-lg font-bold text-gray-900 mb-2">
+                    Handling feedback
+                  </h3>
+                  <p className="text-gray-600 text-sm">
+                    How do they respond to pushback? Defend ideas when right? Accept
+                    criticism gracefully? Adapt or dig in?
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card className="border-2 border-gray-100 hover:border-blue-200 transition-colors">
+                <CardContent className="p-6">
+                  <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mb-4">
+                    <Clock className="w-6 h-6 text-blue-600" />
+                  </div>
+                  <h3 className="text-lg font-bold text-gray-900 mb-2">Work style</h3>
+                  <p className="text-gray-600 text-sm">
+                    Process preferences, seniority calibration, and how they&apos;d fit
+                    your team culture and working style.
+                  </p>
+                </CardContent>
+              </Card>
+            </StaggerReveal>
+          </div>
+        </div>
+        <CurveDivider fillColor="fill-white" />
+      </section>
+
+      {/* Social Proof Section */}
+      <section className="relative py-20 sm:py-24 bg-white">
+        <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="text-center mb-12">
+            <p className="text-sm font-semibold text-blue-600 uppercase tracking-wide mb-4">
+              Trusted by hiring teams
+            </p>
+            <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
+              Companies using Skillvee
+            </h2>
+          </SectionReveal>
+
+          {/* Logo placeholder row */}
+          <SectionReveal className="mb-16">
+            <div className="flex flex-wrap items-center justify-center gap-8 sm:gap-12 opacity-60">
+              {[1, 2, 3, 4, 5].map((i) => (
+                <div
+                  key={i}
+                  className="w-32 h-12 bg-gray-200 rounded flex items-center justify-center"
+                >
+                  <span className="text-xs text-gray-400">Logo {i}</span>
+                </div>
+              ))}
+            </div>
+            <p className="text-center text-sm text-gray-400 mt-4">
+              Placeholder: Add customer logos when available
+            </p>
+          </SectionReveal>
+
+          {/* Testimonial */}
+          <SectionReveal className="max-w-3xl mx-auto">
+            <div className="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-2xl p-8 sm:p-10 border border-blue-100">
+              <div className="flex items-start gap-4">
+                <div className="text-5xl text-blue-300">&ldquo;</div>
+                <div>
+                  <p className="text-lg sm:text-xl text-gray-700 mb-6 italic">
+                    Placeholder: Add a compelling customer quote here. Something like
+                    &ldquo;We reduced bad hires by 40% and our engineering managers
+                    actually enjoy reviewing candidates now.&rdquo;
+                  </p>
+                  <div className="flex items-center gap-4">
+                    <div className="w-12 h-12 bg-gray-300 rounded-full" />
+                    <div>
+                      <p className="font-semibold text-gray-900">Customer Name</p>
+                      <p className="text-sm text-gray-500">
+                        Title, Company
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </SectionReveal>
+        </div>
+        <CurveDivider fillColor="fill-gray-900" />
+      </section>
+
+      {/* Security & Enterprise Section */}
+      <section className="relative py-20 sm:py-24 bg-gray-900">
+        <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="text-center mb-16">
+            <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+              Enterprise-ready from day one
+            </h2>
+            <p className="text-xl text-gray-400 max-w-3xl mx-auto">
+              Your candidate data is secure. Your compliance needs are met.
+            </p>
+          </SectionReveal>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
+            <StaggerReveal className="contents" staggerMs={100}>
+              <div className="text-center">
+                <div className="w-16 h-16 bg-blue-500/20 rounded-2xl flex items-center justify-center mx-auto mb-4">
+                  <Shield className="w-8 h-8 text-blue-400" />
+                </div>
+                <h3 className="text-lg font-bold text-white mb-2">SOC 2 Type II</h3>
+                <p className="text-gray-400 text-sm">
+                  Audited security controls. Your data is protected by industry-standard
+                  practices.
+                </p>
+              </div>
+
+              <div className="text-center">
+                <div className="w-16 h-16 bg-blue-500/20 rounded-2xl flex items-center justify-center mx-auto mb-4">
+                  <Lock className="w-8 h-8 text-blue-400" />
+                </div>
+                <h3 className="text-lg font-bold text-white mb-2">GDPR Compliant</h3>
+                <p className="text-gray-400 text-sm">
+                  Full data privacy compliance for EU candidates. Automatic data retention
+                  policies.
+                </p>
+              </div>
+
+              <div className="text-center">
+                <div className="w-16 h-16 bg-blue-500/20 rounded-2xl flex items-center justify-center mx-auto mb-4">
+                  <Globe className="w-8 h-8 text-blue-400" />
+                </div>
+                <h3 className="text-lg font-bold text-white mb-2">SSO & Integrations</h3>
+                <p className="text-gray-400 text-sm">
+                  SAML SSO, Greenhouse, Lever, and Workday integrations available for
+                  Enterprise.
+                </p>
+              </div>
+            </StaggerReveal>
+          </div>
+
+          <SectionReveal className="text-center mt-12">
+            <Link href="/demo">
+              <Button
+                variant="outline"
+                className="border-white/30 text-white hover:bg-white/10"
+              >
+                Contact us for Enterprise
+              </Button>
+            </Link>
+          </SectionReveal>
+        </div>
+      </section>
+
+      {/* Product FAQ */}
+      <section className="py-20 sm:py-24 bg-white">
+        <div className="max-w-4xl mx-auto px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="text-center mb-12">
+            <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
+              Common questions
+            </h2>
+          </SectionReveal>
+
+          <ProductFAQ />
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="py-20 sm:py-24 bg-gradient-to-br from-blue-600 via-blue-700 to-indigo-800 relative overflow-hidden">
+        <div className="absolute inset-0 overflow-hidden">
+          <div className="absolute top-10 left-10 w-32 h-32 border-2 border-white/10 rounded-full" />
+          <div className="absolute bottom-10 right-10 w-48 h-48 border-2 border-white/10 rounded-full" />
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-white/5 rounded-full blur-3xl" />
+        </div>
+
+        <div className="max-w-4xl mx-auto px-6 sm:px-8 lg:px-6 text-center relative z-10">
+          <SectionReveal>
+            <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-6">
+              Ready to see it yourself?
+            </h2>
+            <p className="text-xl text-blue-100 mb-10 max-w-2xl mx-auto">
+              Get a personalized demo or try a sample assessment as a candidate.
+            </p>
+
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+              <Link href="/demo">
+                <Button
+                  size="lg"
+                  className="min-w-[200px] h-14 text-lg bg-white text-blue-600 hover:bg-blue-50 shadow-lg hover:shadow-xl hover:-translate-y-0.5 transition-all duration-300"
+                >
+                  Request Demo
+                  <ArrowRight className="w-5 h-5 ml-2" />
+                </Button>
+              </Link>
+              <Link href="/demo#sample">
+                <Button
+                  size="lg"
+                  variant="outline"
+                  className="min-w-[200px] h-14 text-lg border-2 border-white text-white hover:bg-white/10"
+                >
+                  Try Sample Assessment
+                </Button>
+              </Link>
+            </div>
+          </SectionReveal>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}
+
+function ProductFAQ() {
+  const [openIndex, setOpenIndex] = useState<number | null>(0);
+
+  const faqs = [
+    {
+      question: "How long does it take to set up a simulation?",
+      answer:
+        "Most simulations are ready in under 5 minutes. Paste your job description, review the generated scenario, customize if needed, and you're ready to send to candidates. No weeks of test design required.",
+    },
+    {
+      question: "Can I customize the simulation for my specific role?",
+      answer:
+        "Yes. The AI generates a baseline from your JD, but you can customize the scenario, stakeholder personas, specific tasks, and evaluation criteria. Enterprise plans include white-glove simulation design support.",
+    },
+    {
+      question: "How do candidates feel about this vs. traditional interviews?",
+      answer:
+        "Candidates consistently rate Skillvee higher than algorithm tests. They appreciate that it's relevant to the actual job, respects their time (30-45 min vs. multi-hour interviews), and lets them show their real skills—not trivia recall.",
+    },
+    {
+      question: "What if a candidate has technical issues?",
+      answer:
+        "Candidates can pause and resume. If issues persist, they can contact support. All sessions are saved automatically, so no work is lost. We also provide a pre-flight check before they start.",
+    },
+    {
+      question: "How accurate is the AI evaluation?",
+      answer:
+        "The AI provides structured signals, not final decisions. You review the transcripts, recordings, and artifacts yourself. Think of it as a well-organized evidence package, not a black-box score.",
+    },
+    {
+      question: "Does it work for non-technical roles?",
+      answer:
+        "Yes. We support any role where you can define realistic work tasks: product managers, data scientists, program managers, operations, and more. If it can be simulated, we can assess it.",
+    },
+  ];
+
+  return (
+    <div className="space-y-3">
+      {faqs.map((faq, index) => (
+        <div
+          key={index}
+          className="border border-gray-200 rounded-xl overflow-hidden"
+        >
+          <button
+            className="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-gray-50 transition-colors"
+            onClick={() => setOpenIndex(openIndex === index ? null : index)}
+          >
+            <span className="font-medium text-gray-900">{faq.question}</span>
+            <ChevronDown
+              className={`w-5 h-5 text-gray-400 transition-transform ${
+                openIndex === index ? "rotate-180" : ""
+              }`}
+            />
+          </button>
+          {openIndex === index && (
+            <div className="px-6 pb-4">
+              <p className="text-gray-600">{faq.answer}</p>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/landing/SectionDivider.tsx
+++ b/src/components/landing/SectionDivider.tsx
@@ -1,0 +1,84 @@
+/**
+ * Smooth wave dividers for seamless section transitions
+ * Creates visual flow between sections with different backgrounds
+ */
+
+interface DividerProps {
+  className?: string;
+  fillColor?: string;
+}
+
+/**
+ * Gentle wave divider - use at bottom of sections
+ */
+export function WaveDivider({ className = "", fillColor = "fill-white" }: DividerProps) {
+  return (
+    <div className={`absolute bottom-0 left-0 right-0 overflow-hidden leading-none ${className}`}>
+      <svg
+        className="relative block w-full h-12 sm:h-16 lg:h-20"
+        viewBox="0 0 1200 120"
+        preserveAspectRatio="none"
+      >
+        <path
+          d="M0,60 C200,100 400,20 600,60 C800,100 1000,20 1200,60 L1200,120 L0,120 Z"
+          className={fillColor}
+        />
+      </svg>
+    </div>
+  );
+}
+
+/**
+ * Inverted wave - use at top of sections
+ */
+export function WaveDividerTop({ className = "", fillColor = "fill-white" }: DividerProps) {
+  return (
+    <div className={`absolute top-0 left-0 right-0 overflow-hidden leading-none rotate-180 ${className}`}>
+      <svg
+        className="relative block w-full h-12 sm:h-16 lg:h-20"
+        viewBox="0 0 1200 120"
+        preserveAspectRatio="none"
+      >
+        <path
+          d="M0,60 C200,100 400,20 600,60 C800,100 1000,20 1200,60 L1200,120 L0,120 Z"
+          className={fillColor}
+        />
+      </svg>
+    </div>
+  );
+}
+
+/**
+ * Subtle curve divider - less dramatic than wave
+ */
+export function CurveDivider({ className = "", fillColor = "fill-white" }: DividerProps) {
+  return (
+    <div className={`absolute bottom-0 left-0 right-0 overflow-hidden leading-none ${className}`}>
+      <svg
+        className="relative block w-full h-10 sm:h-14 lg:h-16"
+        viewBox="0 0 1200 120"
+        preserveAspectRatio="none"
+      >
+        <path
+          d="M0,80 Q600,20 1200,80 L1200,120 L0,120 Z"
+          className={fillColor}
+        />
+      </svg>
+    </div>
+  );
+}
+
+/**
+ * Gradient fade divider - pure CSS, no SVG
+ */
+export function GradientDivider({
+  className = "",
+  from = "from-transparent",
+  to = "to-white"
+}: { className?: string; from?: string; to?: string }) {
+  return (
+    <div
+      className={`absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-b ${from} ${to} pointer-events-none ${className}`}
+    />
+  );
+}

--- a/src/components/landing/SectionReveal.tsx
+++ b/src/components/landing/SectionReveal.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { ReactNode } from "react";
+import { useScrollReveal, getRevealClasses } from "@/hooks/useScrollReveal";
+
+interface SectionRevealProps {
+  children: ReactNode;
+  className?: string;
+  delay?: "delay-100" | "delay-200" | "delay-300" | "delay-400";
+}
+
+/**
+ * Wrapper component that reveals children on scroll
+ */
+export function SectionReveal({ children, className = "", delay }: SectionRevealProps) {
+  const [ref, isVisible] = useScrollReveal<HTMLDivElement>();
+
+  return (
+    <div ref={ref} className={`${getRevealClasses(isVisible, delay)} ${className}`}>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Staggered children reveal - each child animates with increasing delay
+ */
+interface StaggerRevealProps {
+  children: ReactNode[];
+  className?: string;
+  baseDelay?: number;
+  staggerMs?: number;
+}
+
+export function StaggerReveal({
+  children,
+  className = "",
+  baseDelay = 0,
+  staggerMs = 100
+}: StaggerRevealProps) {
+  const [ref, isVisible] = useScrollReveal<HTMLDivElement>();
+
+  return (
+    <div ref={ref} className={className}>
+      {children.map((child, index) => (
+        <div
+          key={index}
+          className="transition-all duration-700 ease-out"
+          style={{
+            opacity: isVisible ? 1 : 0,
+            transform: isVisible ? "translateY(0)" : "translateY(24px)",
+            transitionDelay: `${baseDelay + index * staggerMs}ms`,
+          }}
+        >
+          {child}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useScrollReveal.ts
+++ b/src/hooks/useScrollReveal.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useRef, useState, RefObject } from "react";
+
+interface UseScrollRevealOptions {
+  threshold?: number;
+  rootMargin?: string;
+  triggerOnce?: boolean;
+}
+
+/**
+ * Hook for scroll-triggered reveal animations
+ * Returns a ref to attach to elements and visibility state
+ */
+export function useScrollReveal<T extends HTMLElement = HTMLDivElement>(
+  options: UseScrollRevealOptions = {}
+): [RefObject<T | null>, boolean] {
+  const { threshold = 0.1, rootMargin = "0px 0px -50px 0px", triggerOnce = true } = options;
+  const ref = useRef<T>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          if (triggerOnce) {
+            observer.unobserve(element);
+          }
+        } else if (!triggerOnce) {
+          setIsVisible(false);
+        }
+      },
+      { threshold, rootMargin }
+    );
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [threshold, rootMargin, triggerOnce]);
+
+  return [ref, isVisible];
+}
+
+/**
+ * CSS classes for reveal animations
+ * Use with useScrollReveal hook
+ */
+export const revealClasses = {
+  // Base hidden state
+  hidden: "opacity-0 translate-y-6",
+  // Visible state
+  visible: "opacity-100 translate-y-0",
+  // Transition
+  transition: "transition-all duration-700 ease-out",
+  // Stagger delays for children
+  delay100: "delay-100",
+  delay200: "delay-200",
+  delay300: "delay-300",
+  delay400: "delay-400",
+};
+
+/**
+ * Helper to combine reveal classes based on visibility
+ */
+export function getRevealClasses(isVisible: boolean, delay?: string): string {
+  const base = revealClasses.transition;
+  const state = isVisible ? revealClasses.visible : revealClasses.hidden;
+  return delay ? `${base} ${state} ${delay}` : `${base} ${state}`;
+}


### PR DESCRIPTION
## Summary

- **Hero**: Replaced generic "How It Works" header with video demo placeholder and action-oriented headline
- **Simulation Journey**: Added 4-stage deep-dive showing what candidates actually experience (manager kickoff → requirements gathering → work → present/defend)
- **What You Get**: New section with concrete deliverables (structured scorecard, transcripts, screen recording) with screenshot placeholders
- **Signals Grid**: Kept the differentiated content showing signals you can't get from algorithm tests
- **Social Proof**: Added placeholder section for customer logos and testimonial
- **Enterprise/Security**: New section addressing SOC 2, GDPR, SSO, and integrations
- **Product FAQ**: Added 6 product-specific FAQs addressing common buyer questions

## Why these changes

The previous product page duplicated the homepage "How It Works" section. This redesign:
1. Goes deeper on the product experience instead of repeating homepage content
2. Shows concrete deliverables buyers will receive
3. Addresses enterprise concerns (security, compliance)
4. Adds social proof section (placeholders ready for real content)
5. Answers product-specific questions in the FAQ

## Screenshot placeholders to capture

- Hero: Full product walkthrough video (simulation creation → candidate experience → review dashboard)
- Stage 1: Manager voice call interface with transcript
- Stage 2: Chat with PM showing requirement clarification
- Stage 3: Candidate working with screen recording indicator
- Stage 4: PR defense call with challenging questions
- Scorecard: Structured scorecard with dimension ratings
- Transcripts: Conversation transcript with AI highlights
- Recording: Screen recording player with timeline

## Test plan

- [ ] Verify page renders at `/product`
- [ ] Check scroll animations work correctly
- [ ] Test responsive layout on mobile/tablet
- [ ] Verify all links work (demo, sample assessment)
- [ ] Capture screenshots for placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)