### PR TITLE
feat: add Google Analytics and Microsoft Clarity tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import "./globals.css";
 import { Providers } from "@/components/shared";
 
@@ -18,6 +19,29 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-7E6QFK7SER"
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-7E6QFK7SER');
+          `}
+        </Script>
+        <Script id="microsoft-clarity" strategy="afterInteractive">
+          {`
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "w7oe90kxs6");
+          `}
+        </Script>
+      </head>
       <body className="antialiased">
         <Providers>{children}</Providers>
       </body>


### PR DESCRIPTION
## Summary
- Adds Google Analytics (G-7E6QFK7SER) to track page views and user behavior
- Adds Microsoft Clarity (w7oe90kxs6) for session recordings, heatmaps, and visual debugging
- Both scripts load with `afterInteractive` strategy to avoid blocking page render

## Test plan
- [x] Verified `window.gtag` is available after page load
- [x] Verified `window.clarity` is available after page load
- [x] No console errors from either script
- [ ] Confirm events appear in GA dashboard after deploy
- [ ] Confirm sessions appear in Clarity dashboard after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)