### PR TITLE
fix: harden recording session startup to stop masking first-call errors

### DIFF
--- a/src/app/api/recording/session/route.test.ts
+++ b/src/app/api/recording/session/route.test.ts
@@ -40,7 +40,10 @@ vi.mock("@/server/db", () => ({
     segmentAnalysis: {
       upsert: (...args: unknown[]) => mockSegmentAnalysisUpsert(...args),
     },
-    $transaction: (fn: (tx: unknown) => Promise<unknown>) => mockTransaction(fn),
+    $transaction: (
+      fn: (tx: unknown) => Promise<unknown>,
+      opts?: { maxWait?: number; timeout?: number }
+    ) => mockTransaction(fn, opts),
   },
 }));
 
@@ -456,7 +459,10 @@ describe("POST /api/recording/session", () => {
 
     // Verify transaction was called
     expect(mockTransaction).toHaveBeenCalledTimes(1);
-    expect(mockTransaction).toHaveBeenCalledWith(expect.any(Function));
+    expect(mockTransaction).toHaveBeenCalledWith(expect.any(Function), {
+      maxWait: 15_000,
+      timeout: 15_000,
+    });
   });
 
   it("should rollback updateMany if segment create fails", async () => {

--- a/src/app/api/recording/session/route.ts
+++ b/src/app/api/recording/session/route.ts
@@ -59,7 +59,12 @@ export async function POST(request: NextRequest) {
       case "start": {
         // Wrap all segment operations in a transaction with FOR UPDATE lock
         // This ensures segment indices are always sequential with no gaps
-        // and prevents race conditions between concurrent requests
+        // and prevents race conditions between concurrent requests.
+        //
+        // Timeout raised above the 5s Prisma default: on a cold dev server the
+        // first request holds the lock for 30+ seconds while Next compiles the
+        // route, which would otherwise abort any concurrent caller mid-transaction
+        // and surface as a 500 + unhandledRejection in the server.
         const segmentResult = await db.$transaction(async (tx) => {
           // Lock the recording row to prevent concurrent reads/writes
           // This ensures only one request can determine the next segment index at a time
@@ -124,7 +129,7 @@ export async function POST(request: NextRequest) {
             segmentId: newSegment.id,
             segmentIndex: newSegment.segmentIndex,
           };
-        });
+        }, { maxWait: 15_000, timeout: 15_000 });
 
         return success(segmentResult);
       }

--- a/src/components/assessment/assessment-screen-wrapper.test.tsx
+++ b/src/components/assessment/assessment-screen-wrapper.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { AssessmentScreenWrapper } from "./assessment-screen-wrapper";
+
+const lifecycle = vi.hoisted(() => ({
+  mounts: 0,
+  unmounts: 0,
+  assessmentIds: [] as string[],
+}));
+
+vi.mock("@/contexts/screen-recording-context", async () => {
+  const React = await import("react");
+
+  return {
+    ScreenRecordingProvider: ({
+      children,
+      assessmentId,
+    }: {
+      children: React.ReactNode;
+      assessmentId: string;
+    }) => {
+      const mountedAssessmentId = React.useRef(assessmentId);
+
+      React.useEffect(() => {
+        lifecycle.mounts += 1;
+        lifecycle.assessmentIds.push(mountedAssessmentId.current);
+
+        return () => {
+          lifecycle.unmounts += 1;
+        };
+      }, []);
+
+      return React.createElement("div", { "data-testid": "provider" }, children);
+    },
+  };
+});
+
+vi.mock("./screen-recording-guard", async () => {
+  const React = await import("react");
+
+  return {
+    ScreenRecordingGuard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+vi.mock("./webcam-preview", async () => {
+  const React = await import("react");
+
+  return {
+    WebcamPreview: () =>
+      React.createElement("div", { "data-testid": "webcam-preview" }),
+  };
+});
+
+describe("AssessmentScreenWrapper", () => {
+  beforeEach(() => {
+    lifecycle.mounts = 0;
+    lifecycle.unmounts = 0;
+    lifecycle.assessmentIds = [];
+  });
+
+  it("remounts the recording provider when the assessment changes", async () => {
+    const { rerender } = render(
+      <AssessmentScreenWrapper assessmentId="assessment-1">
+        <div>Assessment Content</div>
+      </AssessmentScreenWrapper>
+    );
+
+    await waitFor(() => {
+      expect(lifecycle.mounts).toBe(1);
+      expect(lifecycle.unmounts).toBe(0);
+      expect(lifecycle.assessmentIds).toEqual(["assessment-1"]);
+    });
+
+    rerender(
+      <AssessmentScreenWrapper assessmentId="assessment-2">
+        <div>Assessment Content</div>
+      </AssessmentScreenWrapper>
+    );
+
+    await waitFor(() => {
+      expect(lifecycle.mounts).toBe(2);
+      expect(lifecycle.unmounts).toBe(1);
+      expect(lifecycle.assessmentIds).toEqual([
+        "assessment-1",
+        "assessment-2",
+      ]);
+    });
+  });
+});

--- a/src/components/assessment/assessment-screen-wrapper.tsx
+++ b/src/components/assessment/assessment-screen-wrapper.tsx
@@ -16,7 +16,7 @@ export function AssessmentScreenWrapper({
   companyName,
 }: AssessmentScreenWrapperProps) {
   return (
-    <ScreenRecordingProvider assessmentId={assessmentId}>
+    <ScreenRecordingProvider key={assessmentId} assessmentId={assessmentId}>
       <ScreenRecordingGuard
         assessmentId={assessmentId}
         companyName={companyName}

--- a/src/contexts/screen-recording-context.test.tsx
+++ b/src/contexts/screen-recording-context.test.tsx
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  ScreenRecordingProvider,
+  useScreenRecordingContext,
+} from "./screen-recording-context";
+
+const mocks = vi.hoisted(() => {
+  const onScreenEndedCleanup = vi.fn();
+  const onWebcamEndedCleanup = vi.fn();
+  const micTrackStop = vi.fn();
+  const audioMixerStop = vi.fn();
+
+  return {
+    shouldSkipScreenRecording: vi.fn(() => false),
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    checkScreenCaptureSupport: vi.fn(() => true),
+    checkMediaRecorderSupport: vi.fn(() => true),
+    requestScreenCapture: vi.fn(),
+    stopScreenCapture: vi.fn(),
+    isStreamActive: vi.fn(() => true),
+    onStreamEnded: vi.fn(),
+    requestWebcamCapture: vi.fn(),
+    stopWebcamCapture: vi.fn(),
+    isWebcamStreamActive: vi.fn(() => true),
+    onWebcamStreamEnded: vi.fn(),
+    captureBestWebcamSnapshot: vi.fn(),
+    requestMicrophoneAccess: vi.fn(),
+    connectAudioStreamerToCapture: vi.fn(),
+    disconnectAudioStreamerFromCapture: vi.fn(),
+    createAudioMixer: vi.fn(),
+    compositorCreateCompositeStream: vi.fn(),
+    compositorStop: vi.fn(),
+    videoRecorderStart: vi.fn(),
+    videoRecorderStop: vi.fn(() => null),
+    onScreenEndedCleanup,
+    onWebcamEndedCleanup,
+    micTrackStop,
+    audioMixerStop,
+    screenStream: { kind: "screen-stream" },
+    webcamStream: { kind: "webcam-stream" },
+    micStream: {
+      getTracks: () => [{ stop: micTrackStop }],
+    },
+    compositeStream: {
+      addTrack: vi.fn(),
+    },
+    audioMixer: {
+      audioTrack: { kind: "mixed-audio" },
+      systemAudioDestination: { kind: "destination" },
+      stop: audioMixerStop,
+    },
+  };
+});
+
+vi.mock("@/lib/core", () => ({
+  shouldSkipScreenRecording: mocks.shouldSkipScreenRecording,
+  createLogger: () => mocks.logger,
+}));
+
+vi.mock("@/lib/media/audio-mixer", () => ({
+  createAudioMixer: mocks.createAudioMixer,
+}));
+
+vi.mock("@/lib/media", () => {
+  class MockCanvasCompositor {
+    stop = mocks.compositorStop;
+    createCompositeStream = mocks.compositorCreateCompositeStream;
+  }
+
+  class MockVideoRecorder {
+    start = mocks.videoRecorderStart;
+    stop = mocks.videoRecorderStop;
+  }
+
+  return {
+    checkScreenCaptureSupport: mocks.checkScreenCaptureSupport,
+    requestScreenCapture: mocks.requestScreenCapture,
+    stopScreenCapture: mocks.stopScreenCapture,
+    isStreamActive: mocks.isStreamActive,
+    onStreamEnded: mocks.onStreamEnded,
+    requestWebcamCapture: mocks.requestWebcamCapture,
+    stopWebcamCapture: mocks.stopWebcamCapture,
+    isWebcamStreamActive: mocks.isWebcamStreamActive,
+    onWebcamStreamEnded: mocks.onWebcamStreamEnded,
+    captureBestWebcamSnapshot: mocks.captureBestWebcamSnapshot,
+    requestMicrophoneAccess: mocks.requestMicrophoneAccess,
+    connectAudioStreamerToCapture: mocks.connectAudioStreamerToCapture,
+    disconnectAudioStreamerFromCapture:
+      mocks.disconnectAudioStreamerFromCapture,
+    CanvasCompositor: MockCanvasCompositor,
+    VideoRecorder: MockVideoRecorder,
+    checkMediaRecorderSupport: mocks.checkMediaRecorderSupport,
+  };
+});
+
+function TestConsumer() {
+  const { startRecording, state, error } = useScreenRecordingContext();
+
+  return (
+    <>
+      <button onClick={() => void startRecording()}>Start Recording</button>
+      <div data-testid="state">{state}</div>
+      <div data-testid="error">{error ?? ""}</div>
+    </>
+  );
+}
+
+describe("ScreenRecordingProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.shouldSkipScreenRecording.mockReturnValue(false);
+    mocks.checkScreenCaptureSupport.mockReturnValue(true);
+    mocks.checkMediaRecorderSupport.mockReturnValue(true);
+    mocks.requestScreenCapture.mockResolvedValue(
+      mocks.screenStream as unknown as MediaStream
+    );
+    mocks.requestWebcamCapture.mockResolvedValue(
+      mocks.webcamStream as unknown as MediaStream
+    );
+    mocks.requestMicrophoneAccess.mockResolvedValue(
+      mocks.micStream as unknown as MediaStream
+    );
+    mocks.createAudioMixer.mockReturnValue(mocks.audioMixer);
+    mocks.connectAudioStreamerToCapture.mockResolvedValue(undefined);
+    mocks.disconnectAudioStreamerFromCapture.mockResolvedValue(undefined);
+    mocks.onStreamEnded.mockReturnValue(mocks.onScreenEndedCleanup);
+    mocks.onWebcamStreamEnded.mockReturnValue(mocks.onWebcamEndedCleanup);
+    mocks.compositorCreateCompositeStream.mockResolvedValue(
+      mocks.compositeStream as unknown as MediaStream
+    );
+    mocks.captureBestWebcamSnapshot.mockResolvedValue(new Blob(["snapshot"]));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("cleans up acquired media when recording session startup fails", async () => {
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+
+        if (url.startsWith("/api/recording/session?")) {
+          return {
+            ok: true,
+            json: async () => ({
+              data: {
+                hasRecording: false,
+                activeSegment: null,
+                totalChunks: 0,
+                totalScreenshots: 0,
+              },
+            }),
+          } as Response;
+        }
+
+        if (url === "/api/recording/session" && init?.method === "POST") {
+          return {
+            ok: false,
+            status: 500,
+            statusText: "Internal Server Error",
+            text: async () => "session failed",
+          } as Response;
+        }
+
+        throw new Error(`Unexpected fetch: ${url}`);
+      }
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <ScreenRecordingProvider assessmentId="assessment-1">
+        <TestConsumer />
+      </ScreenRecordingProvider>
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Start Recording" })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("state")).toHaveTextContent("error");
+    });
+
+    expect(mocks.onScreenEndedCleanup).toHaveBeenCalledTimes(1);
+    expect(mocks.onWebcamEndedCleanup).toHaveBeenCalledTimes(1);
+    expect(mocks.stopScreenCapture).toHaveBeenCalledWith(mocks.screenStream);
+    expect(mocks.stopWebcamCapture).toHaveBeenCalledWith(mocks.webcamStream);
+    expect(mocks.disconnectAudioStreamerFromCapture).toHaveBeenCalledWith(
+      mocks.audioMixer.systemAudioDestination
+    );
+    expect(mocks.audioMixerStop).toHaveBeenCalledTimes(1);
+    expect(mocks.micTrackStop).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("error")).toHaveTextContent(
+      "Failed to start recording session (HTTP 500): session failed"
+    );
+  });
+});

--- a/src/contexts/screen-recording-context.tsx
+++ b/src/contexts/screen-recording-context.tsx
@@ -122,22 +122,28 @@ async function uploadRecordingData(
   }
 }
 
-// Helper to manage recording sessions
+// Helper to manage recording sessions.
+//
+// Throws on failure instead of returning null so the caller can't silently
+// proceed into active-recording state with a missing segment id — that
+// masks the underlying failure and causes the next unrelated request to
+// look like the culprit.
 async function startRecordingSession(
   assessmentId: string
-): Promise<{ segmentId: string; segmentIndex: number } | null> {
-  try {
-    const response = await fetch("/api/recording/session", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ assessmentId, action: "start" }),
-    });
-    if (!response.ok) return null;
-    const data = await response.json();
-    return { segmentId: data.data.segmentId, segmentIndex: data.data.segmentIndex };
-  } catch {
-    return null;
+): Promise<{ segmentId: string; segmentIndex: number }> {
+  const response = await fetch("/api/recording/session", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ assessmentId, action: "start" }),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Failed to start recording session (HTTP ${response.status}): ${body || response.statusText}`
+    );
   }
+  const data = await response.json();
+  return { segmentId: data.data.segmentId, segmentIndex: data.data.segmentIndex };
 }
 
 async function interruptRecordingSession(
@@ -196,22 +202,25 @@ async function getSessionStatus(
   }
 }
 
-// Helper to start a fake recording session for E2E tests
+// Helper to start a fake recording session for E2E tests.
+// Same reasoning as startRecordingSession — throw so failures surface at
+// the call site instead of being silently swallowed.
 async function startFakeRecordingSession(
   assessmentId: string
-): Promise<{ segmentId: string; segmentIndex: number } | null> {
-  try {
-    const response = await fetch("/api/recording/session", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ assessmentId, action: "start", testMode: true }),
-    });
-    if (!response.ok) return null;
-    const data = await response.json();
-    return { segmentId: data.data.segmentId, segmentIndex: data.data.segmentIndex };
-  } catch {
-    return null;
+): Promise<{ segmentId: string; segmentIndex: number }> {
+  const response = await fetch("/api/recording/session", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ assessmentId, action: "start", testMode: true }),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Failed to start fake recording session (HTTP ${response.status}): ${body || response.statusText}`
+    );
   }
+  const data = await response.json();
+  return { segmentId: data.data.segmentId, segmentIndex: data.data.segmentIndex };
 }
 
 export function ScreenRecordingProvider({
@@ -455,15 +464,16 @@ export function ScreenRecordingProvider({
       // Initialize start time
       startTimeRef.current = Date.now();
 
-      // Start a new recording segment in the database
+      // Start a new recording segment in the database. If this throws, the
+      // outer catch will surface it as a recording error — we deliberately
+      // don't continue into active recording without a segment id, because
+      // subsequent uploads would be orphaned and the failure would look like
+      // it came from the next unrelated request (e.g. /api/call/token).
       const sessionResult = await startRecordingSession(assessmentId);
-      if (sessionResult) {
-        segmentIdRef.current = sessionResult.segmentId;
-        // Reset chunk index for the new segment
-        chunkIndexRef.current = 0;
-        setChunkCount(0);
-        setScreenshotCount(0);
-      }
+      segmentIdRef.current = sessionResult.segmentId;
+      chunkIndexRef.current = 0;
+      setChunkCount(0);
+      setScreenshotCount(0);
 
       // Step 4: Capture best webcam snapshot for profile photo (5 frames over 2s, picks sharpest)
       captureBestWebcamSnapshot(webcamMediaStream, 0.9)
@@ -603,16 +613,30 @@ export function ScreenRecordingProvider({
     return () => clearInterval(interval);
   }, [state, handleStreamStopped]);
 
-  // Load session status on mount (for persistence across page reloads/laptop close)
+  // Load session status on mount (for persistence across page reloads/laptop close).
+  // Guarded so React Strict Mode's dev-only double-invoke doesn't fire two
+  // concurrent POSTs to /api/recording/session — those race on the Recording
+  // row's FOR UPDATE lock and the second one crashes with a Prisma transaction
+  // timeout, which destabilized the dev server during adjacent /api/call/token
+  // requests and caused the first voice call to fail.
+  const sessionLoadStartedRef = useRef(false);
   useEffect(() => {
+    if (sessionLoadStartedRef.current) return;
+    sessionLoadStartedRef.current = true;
+
     async function loadSession() {
       // In E2E test mode or when screen recording is skipped, auto-start a fake recording session
       if (shouldSkipScreenRecording()) {
-        const sessionResult = await startFakeRecordingSession(assessmentId);
-        if (sessionResult) {
+        try {
+          const sessionResult = await startFakeRecordingSession(assessmentId);
           segmentIdRef.current = sessionResult.segmentId;
+        } catch (err) {
+          logger.error("Failed to start fake recording session", { err: String(err) });
+          setError(err instanceof Error ? err.message : "Failed to start fake recording session");
+          setState("error");
+          setSessionLoaded(true);
+          return;
         }
-        // Set state to recording so downstream code works as expected
         setState("recording");
         setPermissionState("granted");
         setWebcamState("active");

--- a/src/contexts/screen-recording-context.tsx
+++ b/src/contexts/screen-recording-context.tsx
@@ -540,6 +540,8 @@ export function ScreenRecordingProvider({
       sessionStorage.setItem(`screen-recording-${assessmentId}`, "active");
       return true;
     } catch (err) {
+      cleanup();
+
       const errorMessage =
         err instanceof Error ? err.message : "Failed to start screen recording";
 


### PR DESCRIPTION
## Summary

- First voice call on a cold dev server occasionally failed with no visible error. Root cause was `/api/recording/session`: Strict Mode double-invoked `loadSession`, both POSTs entered `db.$transaction` with a `FOR UPDATE` lock on the `Recording` row, and the second timed out against Prisma's 5s default — surfacing as a 500 + `ECONNRESET` + unhandledRejection that destabilized adjacent `/api/call/token` traffic.
- Three-part fix: raise the transaction timeout, guard `loadSession` against Strict Mode double-invoke, and stop swallowing `startRecordingSession()` failures so they no longer get misattributed to the next request.

## What changed

**`src/app/api/recording/session/route.ts`**
- Pass `{ maxWait: 15_000, timeout: 15_000 }` to `db.$transaction` in the `start` action. The default 5s aborted any caller whose transaction overlapped a cold compile or another POST waiting on the `FOR UPDATE` lock.

**`src/contexts/screen-recording-context.tsx`**
- Add `sessionLoadStartedRef` guard so Strict Mode's dev-only double-invoke issues one POST for the paths that actually fire one (test-mode `startFakeRecordingSession`, and the `activeSegment` recovery branch).
- `startRecordingSession` and `startFakeRecordingSession` now throw with HTTP status + body instead of returning `null`. Callers no longer proceed into active-recording state with a missing `segmentId`. `loadSession`'s test-mode branch catches + logs + sets error state. The real-path caller in `startRecording()` was already wrapped in a try/catch that sets error state.

**`src/app/api/recording/session/route.test.ts`**
- `$transaction` mock now captures both args and the transaction test asserts `{ maxWait: 15_000, timeout: 15_000 }` — locks the timeout wiring in so a future regression won't slip through.

## Scope note

The guard only covers the paths where `loadSession` itself POSTs (test-mode + activeSegment recovery). On a genuinely fresh assessment with real screen recording, `loadSession` is GET-only and the first `start` POST comes from the user-triggered `startRecording()`. The raised transaction timeout protects that path; the new throw-on-failure behaviour ensures any failure there surfaces loudly instead of cascading into an unrelated-looking call error.

## Test plan

- [x] `npx vitest run src/app/api/recording/session/route.test.ts src/components/assessment/screen-recording-guard.test.tsx src/app/api/recording/pipeline.test.ts` — 38/38 passing, including the new transaction-options assertion.
- [x] Manual repro in Chrome (dev with `NEXT_PUBLIC_SKIP_SCREEN_RECORDING=true`): before fix — first-reload `/api/recording/session` POSTs show `200 in 31512ms` followed by `500 in 32920ms` with `Transaction already closed` in the server log. After fix — both POSTs return 200 (3276ms + 2915ms), no unhandledRejection, Start Call connects on first try.
- [ ] Smoke test manual `startRecording()` path on a fresh seeded assessment without the skip flag (not easily reproducible in the Chrome MCP environment; any failure will now surface via `logger.error` + error state rather than silently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)