### PR TITLE
ci: fix i18n-coverage workflow (pgvector + extensions schema)

### DIFF
--- a/.github/workflows/i18n-coverage.yml
+++ b/.github/workflows/i18n-coverage.yml
@@ -39,12 +39,24 @@ jobs:
         run: npx playwright install chromium
 
       - name: Setup environment
+        # Dummy values for every var validated in src/lib/core/env.ts.
+        # The i18n coverage test only renders pages, it doesn't hit
+        # Google/Gemini/Supabase — but env.ts fails the build if any
+        # required var is missing, so we satisfy the schema with
+        # valid-shaped placeholders.
         run: |
           cp .env.example .env.local || touch .env.local
           echo "DATABASE_URL=postgresql://test:test@localhost:5432/testdb" >> .env.local
           echo "DIRECT_URL=postgresql://test:test@localhost:5432/testdb" >> .env.local
+          echo "AUTH_SECRET=test-secret-for-ci" >> .env.local
           echo "NEXTAUTH_SECRET=test-secret-for-ci" >> .env.local
           echo "NEXTAUTH_URL=http://localhost:3000" >> .env.local
+          echo "GOOGLE_CLIENT_ID=test-google-client-id" >> .env.local
+          echo "GOOGLE_CLIENT_SECRET=test-google-client-secret" >> .env.local
+          echo "GEMINI_API_KEY=test-gemini-api-key" >> .env.local
+          echo "SUPABASE_SERVICE_ROLE_KEY=test-supabase-service-role-key" >> .env.local
+          echo "NEXT_PUBLIC_SUPABASE_URL=https://test.supabase.co" >> .env.local
+          echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=test-supabase-anon-key" >> .env.local
           echo "E2E_TEST_MODE=true" >> .env.local
           echo "NEXT_PUBLIC_E2E_TEST_MODE=true" >> .env.local
 
@@ -89,18 +101,26 @@ jobs:
           DIRECT_URL: postgresql://test:test@localhost:5432/testdb
 
       - name: Build Next.js app
+        # SKIP_ENV_VALIDATION lets the build skip t3-oss env schema checks
+        # for secrets we don't carry into CI (Gemini, Google OAuth, Supabase
+        # admin). The test harness doesn't exercise those code paths.
         run: npm run build
         env:
+          SKIP_ENV_VALIDATION: "1"
           DATABASE_URL: postgresql://test:test@localhost:5432/testdb
           DIRECT_URL: postgresql://test:test@localhost:5432/testdb
 
       - name: Run i18n coverage test
         run: npm run test:i18n
         env:
+          SKIP_ENV_VALIDATION: "1"
           DATABASE_URL: postgresql://test:test@localhost:5432/testdb
           DIRECT_URL: postgresql://test:test@localhost:5432/testdb
+          AUTH_SECRET: test-secret-for-ci
           NEXTAUTH_SECRET: test-secret-for-ci
           NEXTAUTH_URL: http://localhost:3000
+          NEXT_PUBLIC_SUPABASE_URL: https://test.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: test-supabase-anon-key
 
       - name: Upload failure screenshots
         if: failure()

--- a/.github/workflows/i18n-coverage.yml
+++ b/.github/workflows/i18n-coverage.yml
@@ -50,13 +50,14 @@ jobs:
 
       - name: Start PostgreSQL
         run: |
+          # pgvector/pgvector ships the `vector` extension Prisma requires.
           docker run -d \
             --name postgres \
             -e POSTGRES_USER=test \
             -e POSTGRES_PASSWORD=test \
             -e POSTGRES_DB=testdb \
             -p 5432:5432 \
-            postgres:15
+            pgvector/pgvector:pg15
 
       - name: Wait for PostgreSQL
         run: |
@@ -68,6 +69,12 @@ jobs:
             echo "Waiting for PostgreSQL..."
             sleep 1
           done
+
+      - name: Prepare Supabase-compatible schemas
+        # The Prisma schema declares `uuid-ossp` in the `extensions` schema
+        # (Supabase convention). Create it before `db push` can CREATE EXTENSION there.
+        run: |
+          docker exec postgres psql -U test -d testdb -c "CREATE SCHEMA IF NOT EXISTS extensions;"
 
       - name: Run database migrations
         run: npx prisma db push --skip-generate


### PR DESCRIPTION
## Summary

Fixes the two remaining infra issues in \`.github/workflows/i18n-coverage.yml\` so the English-leak check can actually run. Follow-up to the partial fixes in PR #378.

- Switched Docker image from \`postgres:15\` to \`pgvector/pgvector:pg15\`. Prisma's datasource block declares \`extensions = [..., vector]\`; vanilla Postgres doesn't ship pgvector.
- Added a step to \`CREATE SCHEMA IF NOT EXISTS extensions\` before \`db push\`. The Prisma schema declares \`uuid_ossp\` in the \`extensions\` schema (Supabase convention) and \`CREATE EXTENSION\` fails if the schema doesn't exist yet.

Closes #381.

## Test plan

- [ ] Workflow runs all the way to the \`Run i18n coverage test\` step (previously failed at \`Run database migrations\`)
- [ ] If leaks are reported, they're real — no more infra false-negatives

🤖 Generated with [Claude Code](https://claude.com/claude-code)