### PR TITLE
test: CI smoke — verify workflows + Codex review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ These look unusual but are correct by design:
 - Minor naming preferences.
 - Missing JSDoc or docstrings.
 - Suggestions to add comments that restate the code.
+- Types that TypeScript already infers — don't suggest adding explicit annotations for locals or return types unless the inference is actually wrong.
+- Missing translation keys in `src/messages/es.json` or `en.json` — the separate `i18n-coverage` workflow handles this.
 
 ## Severity
 


### PR DESCRIPTION
## Summary
- Minor docs tweak to `AGENTS.md` — adds two items to the "Never flag" list so reviewers stop nudging on (a) inferrable type annotations and (b) missing i18n keys (already covered by the i18n-coverage workflow).

## Purpose
Smoke test for the freshly-shipped CI setup:
- Confirm `CI / lint-typecheck` and `CI / unit-tests` jobs run and pass.
- Confirm Codex Cloud auto-review posts a comment using the new `AGENTS.md` 3-lens structure.

## Test plan
- [ ] Both CI jobs go green
- [ ] Codex posts a review comment
- [ ] Review follows the Correctness / Test coverage / Simplicity structure from `AGENTS.md`