### PR TITLE
feat: refresh one-pager market + moat sections

### DIFF
--- a/src/app/[locale]/one-pager/page.tsx
+++ b/src/app/[locale]/one-pager/page.tsx
@@ -325,24 +325,34 @@ export default function OnePageInvestorPage() {
             </div>
             <div
               style={{
-                fontSize: 14,
+                fontSize: 13,
                 color: "#334155",
-                margin: "0 0 12px",
-                lineHeight: 1.6,
+                lineHeight: 1.7,
+                margin: "0 0 16px",
+                display: "flex",
+                flexDirection: "column",
+                gap: 6,
               }}
             >
-              <span
-                style={{ fontSize: 40, fontWeight: 900, color: "#0f172a" }}
-              >
-                $3B
-              </span>
-              <span style={{ fontSize: 13, color: "#64748b" }}>
-                {t("market.tamLabel")}
-              </span>
+              <div>
+                <span style={{ fontWeight: 700, color: "#0f172a" }}>
+                  {t("market.todayValue")}
+                </span>{" "}
+                {t("market.todayDescription")}
+              </div>
+              <div>
+                <span style={{ fontWeight: 700, color: "#0f172a" }}>
+                  {t("market.expandValue")}
+                </span>{" "}
+                {t("market.expandDescription")}
+              </div>
+              <div>
+                <span style={{ fontWeight: 700, color: "#0f172a" }}>
+                  {t("market.visionValue")}
+                </span>{" "}
+                {t("market.visionDescription")}
+              </div>
             </div>
-            <p style={{ fontSize: 14, color: "#334155", fontWeight: 700, margin: "0 0 16px" }}>
-              {t("market.growth")}
-            </p>
             <div
               style={{
                 fontSize: 13,
@@ -373,18 +383,32 @@ export default function OnePageInvestorPage() {
               <Shield size={16} color="#237CF1" />
               <SectionLabel style={{ marginBottom: 0 }}>{t("moat.label")}</SectionLabel>
             </div>
-            <p
+            <div
               style={{
                 fontSize: 13,
                 color: "#334155",
-                margin: "0 0 12px",
-                lineHeight: 1.6,
+                lineHeight: 1.7,
+                margin: "0 0 16px",
+                display: "flex",
+                flexDirection: "column",
+                gap: 6,
               }}
             >
-              {t("moat.introPre")}
-              <span style={{ fontWeight: 700 }}>{t("moat.introHighlight")}</span>
-              {t("moat.introPost")}
-            </p>
+              <div>
+                <span style={{ fontWeight: 700, color: "#0f172a" }}>
+                  {t("moat.pillar1Label")}
+                </span>
+                {" — "}
+                {t("moat.pillar1Desc")}
+              </div>
+              <div>
+                <span style={{ fontWeight: 700, color: "#0f172a" }}>
+                  {t("moat.pillar3Label")}
+                </span>
+                {" — "}
+                {t("moat.pillar3Desc")}
+              </div>
+            </div>
             <div
               style={{
                 background: "#f8fafc",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1973,11 +1973,11 @@
       "label": "The Solution",
       "title": "A 45-min simulation of the real job",
       "item1Title": "Live AI stakeholders",
-      "item1Desc": "Voice conversations with PM, manager, and tech lead — with memory and context",
+      "item1Desc": "Voice conversations with PM, manager, and tech lead",
       "item2Title": "Real deliverables, not trivia",
       "item2Desc": "Candidates produce actual work output — code, PRs, and decisions",
       "item3Title": "Full capture & structured evaluation",
-      "item3Desc": "Screen + voice recorded end-to-end, with scorecards, transcripts, and artifacts",
+      "item3Desc": "Screen + voice recorded end-to-end",
       "footer": "Compare candidates side-by-side on real work."
     },
     "whyNow": {
@@ -1995,16 +1995,21 @@
     },
     "market": {
       "label": "Market",
-      "tamLabel": "pre-hire assessment market",
-      "growth": "Growing 16% CAGR",
+      "todayValue": "$3B",
+      "todayDescription": "pre-hire assessments — today's beachhead, growing 16% CAGR",
+      "expandValue": "$20B+",
+      "expandDescription": "talent acq. software — ATS, sourcing, interview intelligence",
+      "visionValue": "$250B+",
+      "visionDescription": "global recruitment spend as verified work data becomes the matching layer",
       "comparablesLabel": "Comparables:",
-      "comparablesText": "Mercor ($10B), Juicebox ($850M) — AI solved sourcing. HackerRank ($500M, $221M rev) — the incumbent we replace. Evaluation is the missing layer."
+      "comparablesText": "Mercor ($10B), Juicebox ($850M), HackerRank ($500M)"
     },
     "moat": {
       "label": "Moat",
-      "introPre": "Every simulation teaches us what \"good\" looks like ",
-      "introHighlight": "for each company",
-      "introPost": ". As we track which hires succeed, we can predict who will thrive where — not generically, but for each team specifically.",
+      "pillar1Label": "Proprietary data",
+      "pillar1Desc": "every simulation generates behavioral signal competitors don't have",
+      "pillar3Label": "Outcome feedback loop",
+      "pillar3Desc": "we track which hires succeed and sharpen predictions over time",
       "footer": "Competitors can copy the product. They can't copy the data. Starting with engineering, expanding to every white-collar role."
     },
     "businessModel": {

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -1973,11 +1973,11 @@
       "label": "La Solución",
       "title": "Una simulación de 45 min del trabajo real",
       "item1Title": "Stakeholders de IA en vivo",
-      "item1Desc": "Conversaciones de voz con PM, gerente y tech lead — con memoria y contexto",
+      "item1Desc": "Conversaciones de voz con PM, gerente y tech lead",
       "item2Title": "Entregables reales, no trivia",
       "item2Desc": "Los candidatos producen trabajo real — código, PRs y decisiones",
       "item3Title": "Captura completa y evaluación estructurada",
-      "item3Desc": "Pantalla y voz grabadas de principio a fin, con scorecards, transcripciones y artefactos",
+      "item3Desc": "Pantalla y voz grabadas de principio a fin",
       "footer": "Compara candidatos lado a lado en trabajo real."
     },
     "whyNow": {
@@ -1995,16 +1995,21 @@
     },
     "market": {
       "label": "Mercado",
-      "tamLabel": "mercado de evaluación pre-contratación",
-      "growth": "Creciendo 16% CAGR",
+      "todayValue": "$3B",
+      "todayDescription": "evaluación pre-contratación — cabeza de playa actual, creciendo 16% CAGR",
+      "expandValue": "$20B+",
+      "expandDescription": "software de adq. de talento — ATS, sourcing, interview intelligence",
+      "visionValue": "$250B+",
+      "visionDescription": "gasto global en reclutamiento a medida que la data de trabajo verificada se convierte en la capa de matching",
       "comparablesLabel": "Comparables:",
-      "comparablesText": "Mercor ($10B), Juicebox ($850M) — la IA resolvió el sourcing. HackerRank ($500M, $221M ingresos) — el incumbente que reemplazamos. La evaluación es la capa que falta."
+      "comparablesText": "Mercor ($10B), Juicebox ($850M), HackerRank ($500M)"
     },
     "moat": {
       "label": "Moat",
-      "introPre": "Cada simulación nos enseña cómo se ve lo \"bueno\" ",
-      "introHighlight": "para cada empresa",
-      "introPost": ". A medida que rastreamos qué contrataciones tienen éxito, podemos predecir quién prosperará dónde — no de forma genérica, sino para cada equipo en específico.",
+      "pillar1Label": "Data propietaria",
+      "pillar1Desc": "cada simulación genera señal de comportamiento que los competidores no tienen",
+      "pillar3Label": "Loop de retroalimentación de outcomes",
+      "pillar3Desc": "rastreamos qué contrataciones tienen éxito y afinamos las predicciones con el tiempo",
       "footer": "Los competidores pueden copiar el producto. No pueden copiar la data. Empezando con ingeniería, expandiéndonos a todo rol white-collar."
     },
     "businessModel": {


### PR DESCRIPTION
## Summary
- Market section: three explicit TAM tiers ($3B today / $20B+ expansion / $250B+ vision) in place of single headline + separate growth line.
- Moat section: leads with two labeled pillars (Proprietary data + Outcome feedback loop) instead of a paragraph.
- Trims item1/item3 solution descriptions to fit the denser layout.
- en.json + es.json updated with matching keys; EN/ES parity confirmed for solution/market/moat sections.

## Test plan
- [x] Verified rendered output at /en/one-pager and /es/one-pager in dev preview
- [x] npm run check (lint + typecheck) passes
- [ ] CI (lint-typecheck, unit-tests, i18n coverage, Vercel preview) green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)