### PR TITLE
chore(prisma): commit RLS + assessment-column-drop migrations applied to prod

### DIFF
--- a/prisma/migrations/20260422120000_enable_rls_on_public_tables/migration.sql
+++ b/prisma/migrations/20260422120000_enable_rls_on_public_tables/migration.sql
@@ -1,0 +1,27 @@
+-- Enable Row Level Security on every table in the public schema.
+--
+-- The app reads/writes the DB through Prisma (direct Postgres connection,
+-- postgres role) and the Supabase service-role client, both of which bypass
+-- RLS. The only anon-key usage is Supabase Storage, which has its own RLS on
+-- storage.objects and is unaffected by this migration.
+--
+-- With no policies defined, enabling RLS denies all access via the anon and
+-- authenticated roles through PostgREST. This closes the Supabase advisor's
+-- "RLS Disabled in Public" findings.
+--
+-- Done as a DO block so any future tables added to public are covered if this
+-- migration is re-applied manually, and so we don't need to enumerate tables.
+
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT schemaname, tablename
+        FROM pg_tables
+        WHERE schemaname = 'public'
+    LOOP
+        EXECUTE format('ALTER TABLE %I.%I ENABLE ROW LEVEL SECURITY',
+                       r.schemaname, r.tablename);
+    END LOOP;
+END$$;

--- a/prisma/migrations/20260423000000_drop_unused_assessment_columns/migration.sql
+++ b/prisma/migrations/20260423000000_drop_unused_assessment_columns/migration.sql
@@ -1,0 +1,23 @@
+-- Drop 4 unused columns on Assessment.
+--
+-- These columns were restored in prod via two out-of-band migrations on
+-- 2026-04-22 (20260422000000_restore_assessment_columns and
+-- 20260422000001_restore_assessment_columns_2) whose SQL files never landed in
+-- git. The columns were originally removed in commit 67b7845 ("feat: remove
+-- PR/CI infrastructure") and main's code no longer reads them:
+--
+--   ciStatus                 - 0 non-null rows; code refs are for an unrelated
+--                              PrCiStatus runtime type (src/lib/external/github/client.ts)
+--   prSnapshot               - 0 non-null rows; no code refs
+--   prUrl                    - 0 non-null rows; code refs are fields on the same
+--                              PrCiStatus runtime type, not this column
+--   managerMessagesStarted   - 98 rows populated but only referenced by a comment
+--                              at src/components/chat/chat.tsx:202
+--
+-- No FKs, no indexes on any of them. Safe to drop.
+
+ALTER TABLE "Assessment"
+  DROP COLUMN IF EXISTS "ciStatus",
+  DROP COLUMN IF EXISTS "managerMessagesStarted",
+  DROP COLUMN IF EXISTS "prSnapshot",
+  DROP COLUMN IF EXISTS "prUrl";


### PR DESCRIPTION
## Summary

Commits two migration files that were already applied to production (via `prisma db execute` + `migrate resolve --applied` earlier today) but whose SQL was never checked in. Without these files in git, `prisma migrate status` warned about missing migrations and fresh-DB deployments couldn't reproduce prod state.

Both migrations are **already live in prod** — merging this PR is a git-history cleanup, not a functional change.

## Migrations

### `20260422120000_enable_rls_on_public_tables`

Enables Row Level Security on every table in the `public` schema via a `pg_tables` loop. Closes the 5 "RLS Disabled in Public" findings on the Supabase advisor.

Safe because:
- Prisma connects as the `postgres` role (bypasses RLS).
- Server code uses `supabaseAdmin` with `service_role` key (bypasses RLS).
- Client-side `supabase` client only touches Storage (`src/lib/external/storage.ts`), not tables. Storage RLS lives on `storage.objects` and is unaffected.

Verified post-apply: anon-key `GET /rest/v1/User` returns `[]`; service-role returns rows.

### `20260423000000_drop_unused_assessment_columns`

Drops 4 unused columns from `Assessment`: `ciStatus`, `managerMessagesStarted`, `prSnapshot`, `prUrl`.

These were originally removed by `67b7845` ("feat: remove PR/CI infrastructure") but restored to prod out-of-band on 2026-04-22. Audit showed no code path reads them:
- `ciStatus`/`prUrl` hits in `src/lib/external/github/client.ts` reference an unrelated runtime `PrCiStatus` type, not the DB column.
- `managerMessagesStarted` only appears in a comment at `src/components/chat/chat.tsx:202`.
- `prSnapshot` has zero references.

Pre-drop data check: 3 of 4 columns had 0 non-null rows across 98 assessments; `managerMessagesStarted` was populated but nothing reads it.

## Test plan

- [x] Both migrations already applied to prod DB
- [x] `prisma migrate status` reports "Database schema is up to date!"
- [x] `prisma migrate diff --from-url $DIRECT_URL --to-schema-datamodel prisma/schema.prisma` returns empty
- [x] Anon-key PostgREST access to `User`/`Assessment` tables returns `[]` (RLS working)
- [ ] After merge, confirm Supabase advisor's 5 RLS findings clear on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)