### PR TITLE
feat(dashboards): unified gradient across all dashboard sidebars

### DIFF
--- a/src/app/[locale]/admin/components/sidebar.tsx
+++ b/src/app/[locale]/admin/components/sidebar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
+import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -57,10 +58,19 @@ export function AdminSidebar({ user }: AdminSidebarProps) {
     <aside
       className={`${
         sidebarOpen ? "w-64" : "w-16"
-      } flex flex-col bg-[#0B1437] transition-all duration-300`}
+      } flex flex-col bg-[#020617] transition-all duration-300 relative overflow-hidden`}
     >
+      <motion.div
+        animate={{
+          scale: [1, 1.2, 1],
+          opacity: [0.5, 0.8, 0.5],
+        }}
+        transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}
+        className="absolute top-[-30%] left-[-60%] w-[200%] h-[60%] bg-primary/50 rounded-full blur-[100px] pointer-events-none"
+      />
+
       {/* Logo */}
-      <div className="flex h-[72px] items-center justify-between px-4 border-b border-white/10">
+      <div className="relative z-10 flex h-[72px] items-center justify-between px-4 border-b border-white/10">
         {sidebarOpen && (
           <Link href="/admin" className="flex items-center gap-2">
             <Image
@@ -88,7 +98,7 @@ export function AdminSidebar({ user }: AdminSidebarProps) {
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 p-3">
+      <nav className="relative z-10 flex-1 p-3">
         <div className="space-y-1">
           {navItems.map((item) => {
             const active = isActive(item.href, item.exact);
@@ -115,13 +125,13 @@ export function AdminSidebar({ user }: AdminSidebarProps) {
 
       {/* Language Switcher */}
       {sidebarOpen && (
-        <div className="px-3 pb-3">
+        <div className="relative z-10 px-3 pb-3">
           <LanguageSwitcher variant="dark" />
         </div>
       )}
 
       {/* Footer */}
-      <div className="flex h-[72px] items-center border-t border-white/10 px-3">
+      <div className="relative z-10 flex h-[72px] items-center border-t border-white/10 px-3">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             {sidebarOpen ? (

--- a/src/app/[locale]/candidate/dashboard/components/sidebar.tsx
+++ b/src/app/[locale]/candidate/dashboard/components/sidebar.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
 import { useTranslations } from "next-intl";
+import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -48,10 +49,19 @@ export function CandidateSidebar({ user }: CandidateSidebarProps) {
     <aside
       className={`${
         sidebarOpen ? "w-64" : "w-16"
-      } flex flex-col bg-[#0B1437] transition-all duration-300`}
+      } flex flex-col bg-[#020617] transition-all duration-300 relative overflow-hidden`}
     >
+      <motion.div
+        animate={{
+          scale: [1, 1.2, 1],
+          opacity: [0.5, 0.8, 0.5],
+        }}
+        transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}
+        className="absolute top-[-30%] left-[-60%] w-[200%] h-[60%] bg-primary/50 rounded-full blur-[100px] pointer-events-none"
+      />
+
       {/* Logo */}
-      <div className="flex h-[72px] items-center justify-between px-4 border-b border-white/10">
+      <div className="relative z-10 flex h-[72px] items-center justify-between px-4 border-b border-white/10">
         {sidebarOpen && (
           <Link href="/candidate/dashboard" className="flex items-center gap-2">
             <Image
@@ -79,7 +89,7 @@ export function CandidateSidebar({ user }: CandidateSidebarProps) {
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 p-3">
+      <nav className="relative z-10 flex-1 p-3">
         <div className="space-y-1">
           {navItems.map((item) => {
             const active = isActive(item.href, item.exact);
@@ -105,7 +115,7 @@ export function CandidateSidebar({ user }: CandidateSidebarProps) {
       </nav>
 
       {/* Footer */}
-      <div className="flex h-[72px] items-center border-t border-white/10 px-3">
+      <div className="relative z-10 flex h-[72px] items-center border-t border-white/10 px-3">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             {sidebarOpen ? (

--- a/src/app/[locale]/recruiter/components/sidebar.tsx
+++ b/src/app/[locale]/recruiter/components/sidebar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
+import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -47,10 +48,19 @@ export function RecruiterSidebar({ user }: RecruiterSidebarProps) {
     <aside
       className={`${
         sidebarOpen ? "w-64" : "w-16"
-      } flex flex-col bg-[#0B1437] transition-all duration-300`}
+      } flex flex-col bg-[#020617] transition-all duration-300 relative overflow-hidden`}
     >
+      <motion.div
+        animate={{
+          scale: [1, 1.2, 1],
+          opacity: [0.5, 0.8, 0.5],
+        }}
+        transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}
+        className="absolute top-[-30%] left-[-60%] w-[200%] h-[60%] bg-primary/50 rounded-full blur-[100px] pointer-events-none"
+      />
+
       {/* Logo */}
-      <div className="flex h-[72px] items-center justify-between px-4 border-b border-white/10">
+      <div className="relative z-10 flex h-[72px] items-center justify-between px-4 border-b border-white/10">
         {sidebarOpen && (
           <Link href="/recruiter/simulations" className="flex items-center gap-2">
             <Image
@@ -79,7 +89,7 @@ export function RecruiterSidebar({ user }: RecruiterSidebarProps) {
 
       {/* Create Button */}
       {sidebarOpen && (
-        <div className="p-3">
+        <div className="relative z-10 p-3">
           <Button asChild className="w-full bg-blue-600 hover:bg-blue-700">
             <Link href="/recruiter/simulations/new">
               <Plus className="mr-2 h-4 w-4" />
@@ -90,7 +100,7 @@ export function RecruiterSidebar({ user }: RecruiterSidebarProps) {
       )}
 
       {/* Navigation */}
-      <nav className="flex-1 p-3">
+      <nav className="relative z-10 flex-1 p-3">
         <div className="space-y-1">
           {navItems.map((item) => {
             const active = isActive(item.href);
@@ -117,13 +127,13 @@ export function RecruiterSidebar({ user }: RecruiterSidebarProps) {
 
       {/* Language Switcher */}
       {sidebarOpen && (
-        <div className="px-3 pb-3">
+        <div className="relative z-10 px-3 pb-3">
           <LanguageSwitcher variant="dark" />
         </div>
       )}
 
       {/* Footer */}
-      <div className="flex h-[72px] items-center border-t border-white/10 px-3">
+      <div className="relative z-10 flex h-[72px] items-center border-t border-white/10 px-3">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             {sidebarOpen ? (


### PR DESCRIPTION
## Summary
- Applies the welcome page's gradient (dark #020617 base + animated primary-colored blurred blob) to the admin, recruiter, and candidate dashboard sidebars for visual consistency.
- Replaces the previous flat `#0B1437` background across all three sidebars.
- Intensity is dialed up from the welcome page values (50% alpha / 100px blur / tighter positioning) because the sidebar is only 256px wide — the original values rendered nearly invisible at that scale.

## Files changed
- `src/app/[locale]/admin/components/sidebar.tsx`
- `src/app/[locale]/recruiter/components/sidebar.tsx`
- `src/app/[locale]/candidate/dashboard/components/sidebar.tsx`

## Test plan
- [x] `npm run check` passes (only pre-existing warnings)
- [x] Visually verified candidate dashboard sidebar shows the gradient glow
- [x] Visually verified recruiter dashboard sidebar shows the gradient glow
- [x] Visually verified admin dashboard sidebar shows the gradient glow
- [ ] Reviewer: confirm collapsed (w-16) sidebar still looks clean
- [ ] Reviewer: confirm animation feels right (8s pulse) and isn't distracting

🤖 Generated with [Claude Code](https://claude.com/claude-code)