### PR TITLE
fix(embeddings): route embedContent through v1beta client

### DIFF
--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -21,6 +21,12 @@ export const gemini = new GoogleGenAI({
   httpOptions: { apiVersion: "v1alpha" },
 });
 
+// Embedding endpoints are not exposed under v1alpha — use the SDK default
+// (v1beta) for embedContent calls.
+export const geminiEmbeddings = new GoogleGenAI({
+  apiKey: env.GEMINI_API_KEY,
+});
+
 // Generate an ephemeral token for client-side Gemini Live connections
 export async function generateEphemeralToken(config?: {
   systemInstruction?: string;

--- a/src/lib/candidate/embeddings.test.ts
+++ b/src/lib/candidate/embeddings.test.ts
@@ -10,7 +10,7 @@ import { AssessmentDimension, VideoAssessmentStatus } from "@prisma/client";
 
 // Mock the gemini module
 vi.mock("@/lib/ai/gemini", () => ({
-  gemini: {
+  geminiEmbeddings: {
     models: {
       embedContent: vi.fn(),
     },
@@ -34,7 +34,7 @@ vi.mock("@/lib/core/error-recovery", () => ({
 }));
 
 // Import after mocks
-import { gemini } from "@/lib/ai/gemini";
+import { geminiEmbeddings } from "@/lib/ai/gemini";
 import { db } from "@/server/db";
 import {
   EMBEDDING_MODEL,
@@ -52,7 +52,7 @@ import {
 } from "./embeddings";
 
 // Cast mocks for type-safe access
-const mockEmbedContent = gemini.models.embedContent as ReturnType<typeof vi.fn>;
+const mockEmbedContent = geminiEmbeddings.models.embedContent as ReturnType<typeof vi.fn>;
 const mockDbVideoAssessment = db.videoAssessment as unknown as {
   findUnique: ReturnType<typeof vi.fn>;
 };

--- a/src/lib/candidate/embeddings.ts
+++ b/src/lib/candidate/embeddings.ts
@@ -8,7 +8,7 @@
  * @see Issue #67: US-011
  */
 
-import { gemini } from "@/lib/ai/gemini";
+import { geminiEmbeddings } from "@/lib/ai/gemini";
 import { db } from "@/server/db";
 import { withRetry, createLogger } from "@/lib/core";
 
@@ -73,7 +73,7 @@ export type EmbeddingVector = number[];
 export async function generateEmbedding(
   text: string
 ): Promise<EmbeddingVector> {
-  const response = await gemini.models.embedContent({
+  const response = await geminiEmbeddings.models.embedContent({
     model: EMBEDDING_MODEL,
     contents: [{ parts: [{ text }] }],
   });


### PR DESCRIPTION
## Summary
- Post-assessment embedding generation was 404'ing with `models/text-embedding-004 is not found for API version v1alpha`. The shared `gemini` client is pinned to `v1alpha` because Live API ephemeral tokens require it, but `embedContent` isn't exposed under `v1alpha`.
- Added a separate `geminiEmbeddings` client on the SDK default API version (v1beta) and switched `src/lib/candidate/embeddings.ts` to use it. All other `generateContent` callers stay on the v1alpha client untouched.
- Updated the embeddings test mock to match the renamed import.

## Test plan
- [x] `npm run check` clean
- [x] `npx vitest run src/lib/candidate/embeddings.test.ts` — 30/30 pass
- [ ] After merge: confirm next completed assessment generates embeddings without the 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)