### PR TITLE
fix(embeddings): switch to gemini-embedding-001 (text-embedding-004 removed)

### DIFF
--- a/scripts/backfill-embeddings.ts
+++ b/scripts/backfill-embeddings.ts
@@ -1,0 +1,76 @@
+/**
+ * Backfill embeddings for COMPLETED VideoAssessments that are missing them.
+ *
+ * Usage:
+ *   tsx scripts/backfill-embeddings.ts                # dry run: list missing
+ *   tsx scripts/backfill-embeddings.ts --run          # backfill all missing
+ *   tsx scripts/backfill-embeddings.ts <id>           # backfill one specific id
+ */
+import { db } from "../src/server/db";
+import { generateAndStoreEmbeddings } from "../src/lib/candidate/embeddings";
+
+async function findMissing(): Promise<string[]> {
+  const rows = await db.videoAssessment.findMany({
+    where: {
+      status: "COMPLETED",
+      embeddings: null,
+      summary: { isNot: null },
+      scores: { some: {} },
+    },
+    select: { id: true, candidateId: true, completedAt: true },
+    orderBy: { completedAt: "desc" },
+  });
+  console.log(`Found ${rows.length} completed VideoAssessments missing embeddings:`);
+  for (const r of rows) {
+    console.log(`  ${r.id}  candidate=${r.candidateId}  completedAt=${r.completedAt?.toISOString() ?? "n/a"}`);
+  }
+  return rows.map((r) => r.id);
+}
+
+async function backfillOne(id: string): Promise<boolean> {
+  process.stdout.write(`  ${id} ... `);
+  const result = await generateAndStoreEmbeddings(id);
+  if (result.success) {
+    console.log("ok");
+    return true;
+  }
+  console.log(`FAILED: ${result.error}`);
+  return false;
+}
+
+async function main() {
+  const arg = process.argv[2];
+
+  if (arg && arg !== "--run") {
+    // Single-id mode
+    const ok = await backfillOne(arg);
+    process.exit(ok ? 0 : 1);
+  }
+
+  const ids = await findMissing();
+  if (ids.length === 0) {
+    console.log("Nothing to backfill.");
+    return;
+  }
+
+  if (arg !== "--run") {
+    console.log("\nDry run. Re-run with --run to backfill.");
+    return;
+  }
+
+  console.log("\nBackfilling...");
+  let ok = 0;
+  let fail = 0;
+  for (const id of ids) {
+    const success = await backfillOne(id);
+    success ? ok++ : fail++;
+  }
+  console.log(`\nDone: ${ok} succeeded, ${fail} failed`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/src/lib/candidate/embeddings.test.ts
+++ b/src/lib/candidate/embeddings.test.ts
@@ -64,8 +64,8 @@ const mockQueryRaw = db.$queryRaw as unknown as ReturnType<typeof vi.fn>;
 // ============================================================================
 
 describe("Embedding Constants", () => {
-  it("should use text-embedding-004 model", () => {
-    expect(EMBEDDING_MODEL).toBe("text-embedding-004");
+  it("should use gemini-embedding-001 model", () => {
+    expect(EMBEDDING_MODEL).toBe("gemini-embedding-001");
   });
 
   it("should have 768 dimensions", () => {
@@ -93,6 +93,7 @@ describe("generateEmbedding", () => {
     expect(mockEmbedContent).toHaveBeenCalledWith({
       model: EMBEDDING_MODEL,
       contents: [{ parts: [{ text: "Test text" }] }],
+      config: { outputDimensionality: 768 },
     });
     expect(result).toEqual(mockEmbedding);
   });
@@ -450,7 +451,7 @@ describe("getEmbeddingMetadata", () => {
     mockQueryRaw.mockResolvedValue([
       {
         id: "embedding-id",
-        embeddingModel: "text-embedding-004",
+        embeddingModel: "gemini-embedding-001",
         createdAt,
       },
     ]);
@@ -459,7 +460,7 @@ describe("getEmbeddingMetadata", () => {
 
     expect(result).toEqual({
       id: "embedding-id",
-      embeddingModel: "text-embedding-004",
+      embeddingModel: "gemini-embedding-001",
       createdAt,
     });
   });

--- a/src/lib/candidate/embeddings.ts
+++ b/src/lib/candidate/embeddings.ts
@@ -20,13 +20,17 @@ import { AssessmentDimension, VideoAssessmentStatus } from "@prisma/client";
 // ============================================================================
 
 /**
- * Model ID for text embeddings
- * Using text-embedding-004 which produces 768-dimensional embeddings
+ * Model ID for text embeddings.
+ *
+ * `text-embedding-004` was deprecated by Google. Switched to
+ * `gemini-embedding-001` which is the current GA embedding model.
+ * Native output is 3072 dims; we request 768 via outputDimensionality
+ * to match the existing `vector(768)` column.
  */
-export const EMBEDDING_MODEL = "text-embedding-004";
+export const EMBEDDING_MODEL = "gemini-embedding-001";
 
 /**
- * Embedding dimensions (fixed for text-embedding-004)
+ * Embedding dimensions — fixed by the existing `vector(768)` column.
  */
 export const EMBEDDING_DIMENSIONS = 768;
 
@@ -76,6 +80,7 @@ export async function generateEmbedding(
   const response = await geminiEmbeddings.models.embedContent({
     model: EMBEDDING_MODEL,
     contents: [{ parts: [{ text }] }],
+    config: { outputDimensionality: EMBEDDING_DIMENSIONS },
   });
 
   if (!response.embeddings?.[0]?.values) {


### PR DESCRIPTION
## Summary
- Follow-up to [#395](https://github.com/skillvee/simulator/pull/395). Routing `embedContent` to v1beta wasn't enough — `text-embedding-004` itself has been removed from the Gemini API. ListModels confirms only `gemini-embedding-001`, `gemini-embedding-2`, and `gemini-embedding-2-preview` are available.
- Switch to `gemini-embedding-001` (current GA) and request `outputDimensionality: 768` to match the existing `vector(768)` column. Cosine similarity is normalization-invariant, so reduced-dim vectors work without re-normalization.
- Adds `scripts/backfill-embeddings.ts` (dry-run + `--run` + single-id mode), used to recover the 32 completed assessments that had been failing during the regression window. **All 32 already backfilled against prod DB.**

## Followups (not in this PR)
- `prisma/schema.prisma` and the pgvector migration still default `embeddingModel` to `text-embedding-004`. Cosmetic — our code always sets it explicitly — but worth updating in a future schema change.

## Test plan
- [x] `npm run check` clean
- [x] `npx vitest run src/lib/candidate/embeddings.test.ts` — 30/30 pass
- [x] Verified end-to-end: `cmob03ql9...` and 31 others now have embeddings stored
- [ ] Next completed assessment in prod generates embeddings without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)