### PR TITLE
feat(demo): live-demo account bypasses recording + admin reset flow

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,6 +12,13 @@
       }
     },
     {
+      "name": "next-dev-demo-verify",
+      "runtimeExecutable": "/opt/homebrew/bin/node",
+      "runtimeArgs": ["node_modules/.bin/next", "dev"],
+      "port": 3000,
+      "autoPort": false
+    },
+    {
       "name": "prisma-studio",
       "runtimeExecutable": "npx",
       "runtimeArgs": ["prisma", "studio"],

--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,8 @@ RESEND_API_KEY=""
 E2E_TEST_MODE="false"
 NEXT_PUBLIC_E2E_TEST_MODE="false"
 NEXT_PUBLIC_SKIP_SCREEN_RECORDING="false"
+
+# Live-demo account IDs — comma-separated User.id values that skip screen
+# recording on the assessment work page. Set in production for demo runs.
+# Seed creates demo@test.com with id "demo-user".
+DEMO_USER_IDS=""

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "db:studio": "prisma studio",
     "db:migrate": "prisma migrate deploy",
     "db:seed": "tsx prisma/seed.ts",
+    "demo:reset": "tsx scripts/demo-reset.ts",
     "postinstall": "prisma generate"
   },
   "dependencies": {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -29,6 +29,15 @@ const TEST_USERS = {
     name: "Test User",
     role: "USER" as const,
   },
+  // Live-demo account — bypasses screen recording when listed in DEMO_USER_IDS.
+  // Fixed id so DEMO_USER_IDS is deterministic across seeds and environments.
+  demo: {
+    id: "demo-user",
+    email: "demo@test.com",
+    password: "testpassword123",
+    name: "Demo Candidate",
+    role: "USER" as const,
+  },
   // Recruiter-focused flow test users (RF-001)
   recruiter: {
     email: "recruiter@test.com",
@@ -187,6 +196,8 @@ const TEST_USERS = {
 // Fixed test assessment IDs - used by AI agents for visual testing
 const TEST_ASSESSMENT_IDS = {
   chat: "test-assessment-chat", // Status: WORKING - for chat/sidebar testing
+  demo: "demo-assessment", // Status: WORKING - for live product demos (recording bypassed)
+  demoCompleted: "demo-completed-assessment", // Status: COMPLETED - polished results demo
   // Recruiter-focused flow test assessments (RF-001)
   welcome: "test-assessment-welcome", // Status: WELCOME - for welcome page testing
   workingRecruiter: "test-assessment-working-recruiter", // Status: WORKING - for recruiter flow testing
@@ -250,6 +261,7 @@ async function main() {
   const hashedPassword = await hash(TEST_USERS.admin.password, 12);
 
   for (const [key, userData] of Object.entries(TEST_USERS)) {
+    const fixedId = "id" in userData ? (userData as { id: string }).id : undefined;
     const user = await prisma.user.upsert({
       where: { email: userData.email },
       update: {
@@ -259,6 +271,7 @@ async function main() {
         deletedAt: null, // Ensure not soft-deleted
       },
       create: {
+        ...(fixedId ? { id: fixedId } : {}),
         email: userData.email,
         password: hashedPassword,
         name: userData.name,
@@ -405,6 +418,33 @@ Acceptance Criteria:
     console.log(
       `   URL: /assessment/${TEST_ASSESSMENT_IDS.chat}/chat`
     );
+
+    // Demo assessment for the demo user — starts at WELCOME so the live demo
+    // walkthrough begins on the intro screen (candidate clicks "Start
+    // Simulation" to kick off the 90-min timer). Paired with
+    // DEMO_USER_IDS="demo-user" to skip the screen-recording prompt on /work.
+    const demoUser = await prisma.user.findUnique({
+      where: { email: TEST_USERS.demo.email },
+    });
+    if (demoUser) {
+      await prisma.assessment.upsert({
+        where: { id: TEST_ASSESSMENT_IDS.demo },
+        update: {
+          status: "WELCOME",
+          workingStartedAt: null,
+        },
+        create: {
+          id: TEST_ASSESSMENT_IDS.demo,
+          userId: demoUser.id,
+          scenarioId: defaultScenario.id,
+          status: "WELCOME",
+          workingStartedAt: null,
+        },
+      });
+      console.log(
+        `\n🎬 Demo user assessment: /assessments/${TEST_ASSESSMENT_IDS.demo}/welcome (user id: ${demoUser.id})`
+      );
+    }
 
     // Create VideoAssessment with dimension scores for candidate profile testing
     const existingVideoAssessment = await prisma.videoAssessment.findFirst({
@@ -1616,6 +1656,7 @@ Acceptance Criteria:
     TEST_ASSESSMENT_IDS.charlotteBackend, TEST_ASSESSMENT_IDS.henryBackendWorking, TEST_ASSESSMENT_IDS.ameliaBackendWelcome,
     TEST_ASSESSMENT_IDS.carlaBackend, TEST_ASSESSMENT_IDS.alexBackend, TEST_ASSESSMENT_IDS.matiasBackendWelcome,
     TEST_ASSESSMENT_IDS.pepitoBackendWorking,
+    TEST_ASSESSMENT_IDS.demoCompleted,
   ];
   const staleBackend = await prisma.assessment.findMany({
     where: { scenarioId: backendScenario.id, id: { notIn: knownBackendIds } },
@@ -1811,6 +1852,17 @@ Acceptance Criteria:
 
   // === Backend scenario candidates (24 total: 18 completed, 3 working, 3 welcome) ===
   const backendCandidates: Parameters<typeof createCompletedCandidate>[0][] = [
+    // Polished results for the live-demo user — mirrors Sarah Chen's top-performer
+    // scores so the recruiter-view walkthrough looks great on screen.
+    { emailKey: "demo", assessmentId: TEST_ASSESSMENT_IDS.demoCompleted, videoAssessmentId: "va-demo-completed", scenarioId: backendScenario.id, overallScore: 3.75, recommendation: "strong_hire", percentile: 96, daysAgo: 2, summary: "Exceptional systems thinker who designed an elegant rate-limiting solution with sliding windows. Deep Python and Redis expertise, outstanding architectural decisions.", scores: [
+      { dimension: "communication", score: 4, observableBehaviors: "Proactively documented design decisions and trade-offs.", trainableGap: false, timestamps: ["02:00", "15:00", "35:00"] },
+      { dimension: "problem_decomposition_design", score: 4, observableBehaviors: "Expert decomposition of rate-limiting into composable middleware layers.", trainableGap: false, timestamps: ["05:00", "20:00"] },
+      { dimension: "technical_execution", score: 4, observableBehaviors: "Deep Redis and Python expertise. Implemented sliding window with atomic operations.", trainableGap: false, timestamps: ["08:00", "22:00", "40:00"] },
+      { dimension: "collaboration_coachability", score: 3, observableBehaviors: "Engaged well with the team, shared progress updates regularly.", trainableGap: false, timestamps: ["12:00", "30:00"] },
+      { dimension: "practical_maturity", score: 4, observableBehaviors: "Handled edge cases proactively, designed for failure modes.", trainableGap: false, timestamps: ["25:00"] },
+      { dimension: "learning_velocity", score: 4, observableBehaviors: "Owned the design end-to-end, drove decisions confidently.", trainableGap: false, timestamps: ["18:00", "42:00"] },
+      { dimension: "work_process", score: 3, observableBehaviors: "Solid engineering process. Tests first, then implementation.", trainableGap: false, timestamps: ["10:00", "35:00"] },
+    ]},
     { emailKey: "candidateSarah", assessmentId: TEST_ASSESSMENT_IDS.sarahBackend, videoAssessmentId: "va-sarah-backend", scenarioId: backendScenario.id, overallScore: 3.75, recommendation: "strong_hire", percentile: 96, daysAgo: 2, summary: "Exceptional systems thinker who designed an elegant rate-limiting solution with sliding windows. Deep Python and Redis expertise, outstanding architectural decisions.", scores: [
       { dimension: "communication", score: 4, observableBehaviors: "Proactively documented design decisions and trade-offs.", trainableGap: false, timestamps: ["02:00", "15:00", "35:00"] },
       { dimension: "problem_decomposition_design", score: 4, observableBehaviors: "Expert decomposition of rate-limiting into composable middleware layers.", trainableGap: false, timestamps: ["05:00", "20:00"] },

--- a/scripts/demo-reset.ts
+++ b/scripts/demo-reset.ts
@@ -1,0 +1,29 @@
+/**
+ * Demo reset CLI — wipe and recreate the fresh demo assessment.
+ *
+ * Thin wrapper around `resetDemoAssessment()` so the CLI and the admin HTTP
+ * endpoint (POST /api/demo/reset) run identical logic. See that helper for
+ * details on what gets wiped and preserved.
+ *
+ * Run: npm run demo:reset
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { resetDemoAssessment } from "../src/lib/core/demo-reset";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const result = await resetDemoAssessment(prisma);
+  console.log(
+    `✅ Reset ${result.assessmentId} — starts at WELCOME, timer waits for "Start Simulation".`
+  );
+  console.log(`   URL: ${result.welcomeUrl}`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/[locale]/admin/components/reset-demo-button.tsx
+++ b/src/app/[locale]/admin/components/reset-demo-button.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { RotateCcw, CheckCircle2, AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type Result =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ok"; welcomeUrl: string; resultsUrl: string }
+  | { kind: "err"; message: string };
+
+export function ResetDemoButton() {
+  const [state, setState] = useState<Result>({ kind: "idle" });
+
+  const handleClick = async () => {
+    setState({ kind: "loading" });
+    try {
+      const res = await fetch("/api/demo/reset", { method: "POST" });
+      const body = await res.json();
+      if (!res.ok || !body.success) {
+        setState({
+          kind: "err",
+          message: body.error || `HTTP ${res.status}`,
+        });
+        return;
+      }
+      setState({
+        kind: "ok",
+        welcomeUrl: body.data.welcomeUrl,
+        resultsUrl: body.data.resultsUrl,
+      });
+    } catch (e) {
+      setState({ kind: "err", message: e instanceof Error ? e.message : "Failed" });
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Button
+        onClick={handleClick}
+        variant="outline"
+        disabled={state.kind === "loading"}
+        className="shadow-sm hover:shadow-md transition-shadow"
+      >
+        <RotateCcw className="h-4 w-4" />
+        {state.kind === "loading" ? "Resetting…" : "Reset Demo"}
+      </Button>
+
+      {state.kind === "ok" && (
+        <div className="flex flex-col gap-1 rounded-md border border-green-500/30 bg-green-500/5 p-3 text-sm">
+          <div className="flex items-center gap-2 font-medium text-green-700">
+            <CheckCircle2 className="h-4 w-4" />
+            Demo reset — ready for a walkthrough
+          </div>
+          <div className="flex flex-col gap-0.5 pl-6 text-xs text-muted-foreground">
+            <Link
+              href={state.welcomeUrl}
+              className="hover:text-primary hover:underline"
+            >
+              Fresh walkthrough → {state.welcomeUrl}
+            </Link>
+            <Link
+              href={state.resultsUrl}
+              className="hover:text-primary hover:underline"
+            >
+              Polished results → {state.resultsUrl}
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {state.kind === "err" && (
+        <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+          <AlertTriangle className="h-4 w-4" />
+          {state.message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -2,6 +2,7 @@ import { db } from "@/server/db";
 import Link from "next/link";
 import { getAnalytics } from "@/lib/core";
 import { AnalyticsDashboard } from "./analytics-dashboard";
+import { ResetDemoButton } from "./components/reset-demo-button";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -43,6 +44,7 @@ export default async function AdminDashboard() {
           <Button asChild variant="outline" className="shadow-sm hover:shadow-md transition-shadow">
             <Link href="/admin/users">Manage Users</Link>
           </Button>
+          <ResetDemoButton />
         </div>
       </section>
 

--- a/src/app/[locale]/assessments/[id]/work/client.tsx
+++ b/src/app/[locale]/assessments/[id]/work/client.tsx
@@ -57,7 +57,7 @@ export function WorkPageClient({
 }: WorkPageClientProps) {
   const router = useRouter();
   const t = useTranslations("work");
-  const { stopRecording } = useScreenRecordingContext();
+  const { stopRecording, flushFinalChunk } = useScreenRecordingContext();
   const [isCompleting, setIsCompleting] = useState(false);
   const [showTimeUpModal, setShowTimeUpModal] = useState(false);
   const [showSubmitModal, setShowSubmitModal] = useState(false);
@@ -236,7 +236,13 @@ export function WorkPageClient({
     setShowPostDefenseModal(false);
 
     try {
-      stopRecording();
+      // Flush the final in-flight chunk BEFORE finalizing. Once the assessment
+      // flips to COMPLETED, /api/recording rejects uploads with a 400, so the
+      // last seconds of the recording (including the end of the defense call)
+      // would be lost. Streams stay alive — tear down only on finalize success
+      // so a transient failure leaves the user able to retry without being
+      // bounced to /results with a dead recording.
+      await flushFinalChunk();
 
       const response = await fetch("/api/assessment/finalize", {
         method: "POST",
@@ -246,14 +252,17 @@ export function WorkPageClient({
 
       if (!response.ok) {
         logger.error("Failed to finalize assessment", { response: await response.text() });
+        setIsCompleting(false);
+        return;
       }
 
+      stopRecording();
       router.push(`/assessments/${assessmentId}/results`);
     } catch (err) {
-      logger.error("Error completing defense", { error: err });
-      router.push(`/assessments/${assessmentId}/results`);
+      logger.error("Error completing defense", { error: String(err) });
+      setIsCompleting(false);
     }
-  }, [assessmentId, isCompleting, router, stopRecording]);
+  }, [assessmentId, isCompleting, router, stopRecording, flushFinalChunk]);
 
   // Handle post-defense "Continue Working" — dismiss modal and go back to work
   const handleContinueWorking = useCallback(() => {
@@ -267,13 +276,17 @@ export function WorkPageClient({
     setShowTimeUpModal(true);
 
     try {
-      stopRecording();
+      // Flush before finalize so the tail of the recording survives the
+      // COMPLETED status flip (see handleFinalize for the full reasoning).
+      await flushFinalChunk();
 
       await fetch("/api/assessment/finalize", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ assessmentId }),
       });
+
+      stopRecording();
     } catch (err) {
       logger.error("Error finalizing on timeout", { error: String(err) });
     }
@@ -282,7 +295,7 @@ export function WorkPageClient({
     setTimeout(() => {
       router.push(`/assessments/${assessmentId}/results`);
     }, 4000);
-  }, [assessmentId, isCompleting, router, stopRecording]);
+  }, [assessmentId, isCompleting, router, stopRecording, flushFinalChunk]);
 
   // Set up the deadline timer
   useAssessmentDeadline({

--- a/src/app/[locale]/assessments/[id]/work/page.tsx
+++ b/src/app/[locale]/assessments/[id]/work/page.tsx
@@ -4,6 +4,7 @@ import { getAssessmentForChat } from "@/server/queries/assessment";
 import { WorkPageClient } from "./client";
 import { AssessmentScreenWrapper } from "@/components/assessment";
 import { isAssessmentExpired, getDeadlineAt } from "@/lib/core/assessment-timer";
+import { isDemoUser } from "@/lib/core/env";
 import { db } from "@/server/db";
 import { AssessmentStatus } from "@prisma/client";
 import type { ScenarioResource, SimulationDepth } from "@/types";
@@ -75,8 +76,10 @@ export default async function WorkPage({
   const resources = (assessment.scenario.resources as unknown as ScenarioResource[]) || [];
   const language = assessment.scenario.language || undefined;
 
+  const bypassRecording = isDemoUser(session.user.id);
+
   return (
-    <AssessmentScreenWrapper assessmentId={id}>
+    <AssessmentScreenWrapper assessmentId={id} bypassRecording={bypassRecording}>
       <WorkPageClient
         assessmentId={id}
         coworkers={coworkers}

--- a/src/app/api/demo/reset/route.ts
+++ b/src/app/api/demo/reset/route.ts
@@ -1,0 +1,36 @@
+import { getSessionWithRole, isAdmin, createLogger } from "@/lib/core";
+import { resetDemoAssessment } from "@/lib/core/demo-reset";
+import { db } from "@/server/db";
+import { success, error } from "@/lib/api";
+
+const logger = createLogger("api:demo:reset");
+
+// POST /api/demo/reset — admin-only.
+// Wipes and recreates the fresh demo assessment so the next walkthrough
+// starts from the welcome screen with a clean timer. Leaves the polished
+// demo-completed-assessment untouched.
+//
+// Uses manual auth checks (not requireAdmin) because requireAdmin's redirect()
+// throws NEXT_REDIRECT, which collapses to a 500 in API routes. We want proper
+// 401/403 JSON responses so the client can render a useful error.
+export async function POST() {
+  try {
+    const session = await getSessionWithRole();
+    if (!session?.user) {
+      return error("Unauthorized", 401);
+    }
+    if (!isAdmin(session.user)) {
+      return error("Admin access required", 403);
+    }
+
+    const result = await resetDemoAssessment(db);
+    logger.info("Demo assessment reset", { adminId: session.user.id });
+    return success(result);
+  } catch (err) {
+    logger.error("Demo reset failed", { err: String(err) });
+    return error(
+      err instanceof Error ? err.message : "Failed to reset demo",
+      500
+    );
+  }
+}

--- a/src/app/api/recording/session/route.ts
+++ b/src/app/api/recording/session/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { auth } from "@/auth";
 import { db } from "@/server/db";
-import { shouldAllowTestModeRecording } from "@/lib/core/env";
+import { shouldAllowTestModeRecording, isDemoUser } from "@/lib/core/env";
 import { createLogger } from "@/lib/core";
 import { success, error, validateRequest } from "@/lib/api";
 import { RecordingSessionSchema } from "@/lib/schemas";
@@ -23,8 +23,13 @@ export async function POST(request: NextRequest) {
     if ("error" in validated) return validated.error;
     const { assessmentId, action, segmentId, chunkPath, screenshotPath, testMode } = validated.data;
 
-    // Reject testMode requests if not in development mode (double-gate safety)
-    if (testMode && !shouldAllowTestModeRecording()) {
+    // Reject testMode requests unless this is a dev/E2E environment OR the
+    // caller is a designated demo user (prod demos bypass recording too).
+    if (
+      testMode &&
+      !shouldAllowTestModeRecording() &&
+      !isDemoUser(session.user.id)
+    ) {
       return error("Test mode is only available in development environment", 403);
     }
 

--- a/src/components/assessment/assessment-screen-wrapper.tsx
+++ b/src/components/assessment/assessment-screen-wrapper.tsx
@@ -8,20 +8,29 @@ interface AssessmentScreenWrapperProps {
   children: React.ReactNode;
   assessmentId: string;
   companyName?: string;
+  /** Skip screen/webcam/mic capture entirely — used for live product demos
+   *  where the recorder competes with screen sharing (e.g. Google Meet). */
+  bypassRecording?: boolean;
 }
 
 export function AssessmentScreenWrapper({
   children,
   assessmentId,
   companyName,
+  bypassRecording,
 }: AssessmentScreenWrapperProps) {
   return (
-    <ScreenRecordingProvider key={assessmentId} assessmentId={assessmentId}>
+    <ScreenRecordingProvider
+      key={assessmentId}
+      assessmentId={assessmentId}
+      bypassRecording={bypassRecording}
+    >
       <ScreenRecordingGuard
         assessmentId={assessmentId}
         companyName={companyName}
+        bypassRecording={bypassRecording}
       >
-        <WebcamPreview />
+        {!bypassRecording && <WebcamPreview />}
         {children}
       </ScreenRecordingGuard>
     </ScreenRecordingProvider>

--- a/src/components/assessment/screen-recording-guard.test.tsx
+++ b/src/components/assessment/screen-recording-guard.test.tsx
@@ -28,9 +28,13 @@ const mockContextValue = {
   webcamState: "idle" as string,
   webcamStream: null,
   sessionLoaded: true,
+  permissionBlock: null as
+    | null
+    | { device: "camera" | "microphone"; reason: "site-block" | "embargo" | "unknown" },
   startRecording: vi.fn().mockResolvedValue(true),
   stopRecording: vi.fn(),
   retryRecording: vi.fn().mockResolvedValue(true),
+  flushFinalChunk: vi.fn().mockResolvedValue(undefined),
 };
 
 vi.mock("@/contexts/screen-recording-context", () => ({
@@ -46,6 +50,7 @@ describe("ScreenRecordingGuard", () => {
     mockContextValue.error = null;
     mockContextValue.isRecording = false;
     mockContextValue.sessionLoaded = true;
+    mockContextValue.permissionBlock = null;
   });
 
   it("shows initial consent modal for fresh start (idle state)", () => {
@@ -181,6 +186,62 @@ describe("ScreenRecordingGuard", () => {
 
     expect(screen.queryByText("Recording Notice")).not.toBeInTheDocument();
     expect(screen.queryByText("Recording Stopped")).not.toBeInTheDocument();
+  });
+
+  it("shows embargo-specific instructions when permissionBlock.reason is 'embargo'", () => {
+    mockContextValue.state = "error";
+    mockContextValue.permissionBlock = { device: "camera", reason: "embargo" };
+
+    render(
+      <ScreenRecordingGuard assessmentId="test-id">
+        <div>Assessment Content</div>
+      </ScreenRecordingGuard>
+    );
+
+    expect(screen.getByText("Allow Camera Access")).toBeInTheDocument();
+    expect(
+      screen.getByText(/auto-rejected the camera prompt/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Reset permissions/)).toBeInTheDocument();
+    // Should NOT fall through to the generic retry modal
+    expect(screen.queryByText("Recording Stopped")).not.toBeInTheDocument();
+    expect(screen.queryByText("Resume Recording")).not.toBeInTheDocument();
+  });
+
+  it("shows site-block instructions when permissionBlock.reason is 'site-block'", () => {
+    mockContextValue.state = "error";
+    mockContextValue.permissionBlock = {
+      device: "microphone",
+      reason: "site-block",
+    };
+
+    render(
+      <ScreenRecordingGuard assessmentId="test-id">
+        <div>Assessment Content</div>
+      </ScreenRecordingGuard>
+    );
+
+    expect(screen.getByText("Allow Microphone Access")).toBeInTheDocument();
+    expect(
+      screen.getByText(/blocking microphone access for this site/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Recording Stopped")).not.toBeInTheDocument();
+  });
+
+  it("shows generic instructions when permissionBlock.reason is 'unknown'", () => {
+    mockContextValue.state = "error";
+    mockContextValue.permissionBlock = { device: "camera", reason: "unknown" };
+
+    render(
+      <ScreenRecordingGuard assessmentId="test-id">
+        <div>Assessment Content</div>
+      </ScreenRecordingGuard>
+    );
+
+    expect(screen.getByText("Allow Camera Access")).toBeInTheDocument();
+    expect(
+      screen.getByText(/blocked camera access for this site/i)
+    ).toBeInTheDocument();
   });
 
   it("shows resume modal when DB has prior recording (simulates browser close + reopen)", () => {

--- a/src/components/assessment/screen-recording-guard.tsx
+++ b/src/components/assessment/screen-recording-guard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { Monitor, Mic, Camera, AlertTriangle, ArrowRight } from "lucide-react";
+import { Monitor, Mic, Camera, AlertTriangle, ArrowRight, RotateCw } from "lucide-react";
 import { useScreenRecordingContext } from "@/contexts/screen-recording-context";
+import type { PermissionBlock } from "@/contexts/screen-recording-context";
 import { shouldSkipScreenRecording } from "@/lib/core";
 import {
   Dialog,
@@ -18,15 +19,17 @@ interface ScreenRecordingGuardProps {
   children: React.ReactNode;
   assessmentId: string;
   companyName?: string;
+  bypassRecording?: boolean;
 }
 
 export function ScreenRecordingGuard({
   children,
   assessmentId,
   companyName = "the company",
+  bypassRecording,
 }: ScreenRecordingGuardProps) {
-  // In E2E test mode or when screen recording is skipped, bypass the guard entirely
-  if (shouldSkipScreenRecording()) {
+  // Bypass the guard for E2E test mode, dev skip flag, or demo-user prod path.
+  if (bypassRecording || shouldSkipScreenRecording()) {
     return <>{children}</>;
   }
 
@@ -50,6 +53,7 @@ function ScreenRecordingGuardInner({
     error,
     isRecording,
     sessionLoaded,
+    permissionBlock,
     startRecording,
     retryRecording,
   } = useScreenRecordingContext();
@@ -79,9 +83,28 @@ function ScreenRecordingGuardInner({
     return null;
   }
 
+  // Assessment was deliberately finalized — pass through while navigation to
+  // /results is in flight. Without this, stopRecording() would flip the guard
+  // into showing the initial consent modal again.
+  if (state === "ended") {
+    return <>{children}</>;
+  }
+
   // Recording is active or browser permission dialogs are showing — allow access
   if (!shouldBlock) {
     return <>{children}</>;
+  }
+
+  // Browser-level block (site setting or Chrome embargo) — "Resume Recording"
+  // can't fix this because the browser won't show another prompt. Show the
+  // device-specific instructions modal instead.
+  if (permissionBlock) {
+    return (
+      <>
+        <BlockedPermissionModal block={permissionBlock} />
+        <div className="pointer-events-none blur-sm">{children}</div>
+      </>
+    );
   }
 
   // Recording stopped or errored — show retry modal
@@ -277,5 +300,129 @@ function ScreenRecordingGuardInner({
       {/* Render children behind the overlay (hidden) */}
       <div className="pointer-events-none blur-sm">{children}</div>
     </>
+  );
+}
+
+function BlockedPermissionModal({ block }: { block: NonNullable<PermissionBlock> }) {
+  const deviceLabel = block.device === "camera" ? "Camera" : "Microphone";
+  const DeviceIcon = block.device === "camera" ? Camera : Mic;
+
+  // Both remediation paths end in "reload the page" because neither a changed
+  // site setting nor a cleared embargo takes effect until the next navigation.
+  const handleReload = () => {
+    window.location.reload();
+  };
+
+  // Copy differs by cause — embargo needs "Reset permissions", site block
+  // needs "change to Allow". Generic fallback covers cases where the
+  // Permissions API couldn't classify.
+  const instructions =
+    block.reason === "site-block" ? (
+      <>
+        <p className="mb-3 font-medium text-foreground">
+          Your browser is blocking {deviceLabel.toLowerCase()} access for this site.
+        </p>
+        <ol className="space-y-2 text-sm text-muted-foreground">
+          <li>
+            <strong className="text-foreground">1.</strong> Click the tune icon
+            (⚙︎) or lock icon to the left of the URL at the top of your browser.
+          </li>
+          <li>
+            <strong className="text-foreground">2.</strong> Find{" "}
+            <strong>{deviceLabel}</strong> in the list and change it from{" "}
+            <strong>Block</strong> to <strong>Allow</strong>.
+          </li>
+          <li>
+            <strong className="text-foreground">3.</strong> Reload this page
+            using the button below.
+          </li>
+        </ol>
+      </>
+    ) : block.reason === "embargo" ? (
+      <>
+        <p className="mb-3 font-medium text-foreground">
+          Your browser auto-rejected the {deviceLabel.toLowerCase()} prompt
+          after it was dismissed a few times.
+        </p>
+        <p className="mb-3 text-sm text-muted-foreground">
+          This is a privacy feature — the site setting still shows{" "}
+          <strong>Ask</strong>, but the browser won&apos;t show the prompt
+          again until you reset it.
+        </p>
+        <ol className="space-y-2 text-sm text-muted-foreground">
+          <li>
+            <strong className="text-foreground">1.</strong> Click the tune icon
+            (⚙︎) or lock icon to the left of the URL at the top of your browser.
+          </li>
+          <li>
+            <strong className="text-foreground">2.</strong> Click{" "}
+            <strong>Reset permissions</strong>.
+          </li>
+          <li>
+            <strong className="text-foreground">3.</strong> Reload this page —
+            the {deviceLabel.toLowerCase()} prompt will appear again.
+          </li>
+        </ol>
+      </>
+    ) : (
+      <>
+        <p className="mb-3 font-medium text-foreground">
+          Your browser blocked {deviceLabel.toLowerCase()} access for this site.
+        </p>
+        <ol className="space-y-2 text-sm text-muted-foreground">
+          <li>
+            <strong className="text-foreground">1.</strong> Click the tune icon
+            (⚙︎) or lock icon to the left of the URL at the top of your browser.
+          </li>
+          <li>
+            <strong className="text-foreground">2.</strong> Set{" "}
+            <strong>{deviceLabel}</strong> to <strong>Allow</strong>, or click{" "}
+            <strong>Reset permissions</strong>.
+          </li>
+          <li>
+            <strong className="text-foreground">3.</strong> Reload this page
+            using the button below.
+          </li>
+        </ol>
+      </>
+    );
+
+  return (
+    <Dialog open={true}>
+      <DialogContent
+        className="max-w-md"
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <div className="mb-4 flex justify-center">
+            <div className="rounded-xl bg-destructive/10 p-4">
+              <DeviceIcon className="h-12 w-12 text-destructive" />
+            </div>
+          </div>
+
+          <DialogTitle className="text-center text-2xl">
+            Allow {deviceLabel} Access
+          </DialogTitle>
+          <DialogDescription className="text-center">
+            We need {deviceLabel.toLowerCase()} access to continue the assessment
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-lg bg-muted p-6">{instructions}</div>
+
+        <DialogFooter className="flex-col gap-3 sm:flex-col">
+          <Button onClick={handleReload} size="lg" className="w-full">
+            <RotateCw className="h-4 w-4" />
+            Reload Page
+          </Button>
+
+          <p className="text-center text-sm text-muted-foreground">
+            Still stuck? On macOS, also check System Settings → Privacy &
+            Security → {deviceLabel} and make sure your browser is enabled.
+          </p>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/contexts/screen-recording-context.tsx
+++ b/src/contexts/screen-recording-context.tsx
@@ -41,9 +41,27 @@ export type ScreenRecordingState =
   | "requesting"
   | "recording"
   | "stopped"
-  | "error";
+  | "error"
+  | "ended";
 
 export type WebcamState = "idle" | "requesting" | "active" | "denied" | "error";
+
+/**
+ * Describes the specific reason a camera/mic permission request failed,
+ * which determines what instructions to show the user.
+ *
+ * - `site-block`: the browser has camera/mic set to "Block" for this origin
+ *   (explicit deny or Chrome Settings). Fix: change the setting to Allow.
+ * - `embargo`: Chrome silently auto-rejected the prompt after the user
+ *   dismissed it 2-3 times. Site setting still shows "Ask" in the UI.
+ *   Fix: Reset permissions to clear the embargo counter.
+ * - `unknown`: the Permissions API didn't give us a useful answer (old
+ *   browser, extension interference, etc.) — show generic instructions.
+ */
+export type PermissionBlock = {
+  device: "camera" | "microphone";
+  reason: "site-block" | "embargo" | "unknown";
+} | null;
 
 interface ScreenRecordingContextValue {
   state: ScreenRecordingState;
@@ -56,6 +74,11 @@ interface ScreenRecordingContextValue {
   webcamState: WebcamState;
   webcamStream: MediaStream | null;
   sessionLoaded: boolean;
+  /** Non-null when the last getUserMedia call rejected with NotAllowedError
+   *  and the Permissions API lets us classify why. Guard uses this to pick
+   *  the right remediation copy instead of the generic "Resume Recording"
+   *  button, which can't recover from a browser-level block. */
+  permissionBlock: PermissionBlock;
   /** AudioContext destination node for capturing system audio in the recording.
    *  Voice hooks should connect their audio output here (in addition to speakers)
    *  so that AI voice responses are included in the screen recording. */
@@ -63,6 +86,39 @@ interface ScreenRecordingContextValue {
   startRecording: () => Promise<boolean>;
   stopRecording: () => void;
   retryRecording: () => Promise<boolean>;
+  /** Stop the MediaRecorder and await all pending chunk uploads WITHOUT
+   *  tearing down streams or marking the segment complete. Call before
+   *  /api/assessment/finalize so the final chunk lands before the
+   *  assessment flips to COMPLETED (which would reject the upload 400).
+   *  Idempotent. */
+  flushFinalChunk: () => Promise<void>;
+}
+
+/**
+ * Classify why a getUserMedia call rejected with NotAllowedError.
+ *
+ * getUserMedia collapses distinct failure modes into one error. The
+ * Permissions API lets us disambiguate: `denied` means site-level block,
+ * `prompt` after a rejected request means embargo (Chrome silently
+ * auto-rejecting after repeated dismissals). Returns "unknown" for
+ * browsers/states where we can't tell.
+ */
+async function classifyPermissionBlock(
+  device: "camera" | "microphone"
+): Promise<"site-block" | "embargo" | "unknown"> {
+  try {
+    if (typeof navigator === "undefined" || !navigator.permissions) {
+      return "unknown";
+    }
+    const status = await navigator.permissions.query({
+      name: device as PermissionName,
+    });
+    if (status.state === "denied") return "site-block";
+    if (status.state === "prompt") return "embargo";
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
 }
 
 const ScreenRecordingContext =
@@ -71,6 +127,10 @@ const ScreenRecordingContext =
 interface ScreenRecordingProviderProps {
   children: ReactNode;
   assessmentId: string;
+  /** Server-computed flag: when true, take the same fake-session path as
+   *  the E2E skip flag. Enables demoing the candidate flow in production
+   *  without triggering getUserMedia. */
+  bypassRecording?: boolean;
 }
 
 // Helper function to upload a chunk or screenshot
@@ -226,6 +286,7 @@ async function startFakeRecordingSession(
 export function ScreenRecordingProvider({
   children,
   assessmentId,
+  bypassRecording,
 }: ScreenRecordingProviderProps) {
   const [state, setState] = useState<ScreenRecordingState>("idle");
   const [permissionState, setPermissionState] =
@@ -236,6 +297,7 @@ export function ScreenRecordingProvider({
   const [sessionLoaded, setSessionLoaded] = useState(false);
   const [webcamState, setWebcamState] = useState<WebcamState>("idle");
   const [webcamStream, setWebcamStream] = useState<MediaStream | null>(null);
+  const [permissionBlock, setPermissionBlock] = useState<PermissionBlock>(null);
 
   const streamRef = useRef<MediaStream | null>(null);
   const webcamStreamRef = useRef<MediaStream | null>(null);
@@ -248,6 +310,25 @@ export function ScreenRecordingProvider({
   const chunkIndexRef = useRef(0);
   const startTimeRef = useRef<number | null>(null);
   const segmentIdRef = useRef<string | null>(null);
+  // Tracks in-flight upload promises so `flushFinalChunk` can await them all.
+  const pendingUploadsRef = useRef<Set<Promise<unknown>>>(new Set());
+  // Set once `flushFinalChunk` has stopped the recorder + awaited uploads, so
+  // the subsequent `stopRecording()` teardown doesn't double-stop or re-upload.
+  const flushedRef = useRef(false);
+
+  // Wraps a fire-and-forget upload so `flushFinalChunk` can await all
+  // in-flight uploads before finalize. Returns the same promise so callers
+  // that do await still work.
+  const trackUpload = useCallback(
+    <T,>(promise: Promise<T>): Promise<T> => {
+      pendingUploadsRef.current.add(promise);
+      promise.finally(() => {
+        pendingUploadsRef.current.delete(promise);
+      });
+      return promise;
+    },
+    []
+  );
 
   const isSupported =
     checkScreenCaptureSupport() && checkMediaRecorderSupport();
@@ -257,13 +338,15 @@ export function ScreenRecordingProvider({
     if (videoRecorderRef.current) {
       const finalBlob = videoRecorderRef.current.stop();
       if (finalBlob && finalBlob.size > 0) {
-        uploadRecordingData(
-          assessmentId,
-          finalBlob,
-          "video",
-          chunkIndexRef.current,
-          startTimeRef.current || Date.now(),
-          segmentIdRef.current || undefined
+        trackUpload(
+          uploadRecordingData(
+            assessmentId,
+            finalBlob,
+            "video",
+            chunkIndexRef.current,
+            startTimeRef.current || Date.now(),
+            segmentIdRef.current || undefined
+          )
         );
       }
       videoRecorderRef.current = null;
@@ -305,7 +388,7 @@ export function ScreenRecordingProvider({
     streamRef.current = null;
     // Clear session storage
     sessionStorage.removeItem(`screen-recording-${assessmentId}`);
-  }, [assessmentId]);
+  }, [assessmentId, trackUpload]);
 
   const cleanup = useCallback(() => {
     // Stop video recording
@@ -364,6 +447,7 @@ export function ScreenRecordingProvider({
     cleanup();
     setState("requesting");
     setError(null);
+    setPermissionBlock(null);
 
     try {
       // Step 1: Request screen capture
@@ -390,6 +474,16 @@ export function ScreenRecordingProvider({
         stopScreenCapture(screenStream);
         streamRef.current = null;
 
+        // Diagnostic: the catch branch below collapses multiple distinct failure
+        // modes (site block, OS block, Chrome embargo, dismissed prompt, extension
+        // interference, device in use) into one "NotAllowedError" bucket. Log the
+        // raw DOMException details so we can tell them apart.
+        logger.error("Webcam request failed", {
+          name: webcamErr instanceof DOMException ? webcamErr.name : "non-DOMException",
+          message: webcamErr instanceof Error ? webcamErr.message : String(webcamErr),
+          constructor: webcamErr?.constructor?.name ?? "unknown",
+        });
+
         if (
           webcamErr instanceof DOMException &&
           (webcamErr.name === "NotAllowedError" ||
@@ -397,6 +491,8 @@ export function ScreenRecordingProvider({
         ) {
           setWebcamState("denied");
           setError("Webcam permission was denied. Both screen and webcam recording are required.");
+          const reason = await classifyPermissionBlock("camera");
+          setPermissionBlock({ device: "camera", reason });
         } else {
           setWebcamState("error");
           setError("Failed to access webcam. Please ensure your camera is connected and not in use by another application.");
@@ -426,12 +522,23 @@ export function ScreenRecordingProvider({
         setWebcamStream(null);
         setWebcamState("idle");
 
+        // Same classification as the webcam catch — the error bucket for
+        // "NotAllowedError" hides whether this is a site block, a Chrome
+        // embargo, or something else, and each needs different copy.
+        logger.error("Microphone request failed", {
+          name: micErr instanceof DOMException ? micErr.name : "non-DOMException",
+          message: micErr instanceof Error ? micErr.message : String(micErr),
+          constructor: micErr?.constructor?.name ?? "unknown",
+        });
+
         if (
           micErr instanceof DOMException &&
           (micErr.name === "NotAllowedError" ||
             micErr.name === "PermissionDeniedError")
         ) {
           setError("Microphone permission was denied. Screen, webcam, and microphone are all required.");
+          const reason = await classifyPermissionBlock("microphone");
+          setPermissionBlock({ device: "microphone", reason });
         } else {
           setError("Failed to access microphone. Please ensure your microphone is connected and not in use by another application.");
         }
@@ -478,14 +585,16 @@ export function ScreenRecordingProvider({
       // Step 4: Capture best webcam snapshot for profile photo (5 frames over 2s, picks sharpest)
       captureBestWebcamSnapshot(webcamMediaStream, 0.9)
         .then((snapshot) => {
-          uploadRecordingData(
-            assessmentId,
-            snapshot,
-            "screenshot",
-            undefined,
-            Date.now(),
-            segmentIdRef.current || undefined,
-            "webcam-profile"
+          trackUpload(
+            uploadRecordingData(
+              assessmentId,
+              snapshot,
+              "screenshot",
+              undefined,
+              Date.now(),
+              segmentIdRef.current || undefined,
+              "webcam-profile"
+            )
           );
         })
         .catch((err) => {
@@ -506,25 +615,29 @@ export function ScreenRecordingProvider({
             chunkIndexRef.current += 1;
             setChunkCount((prev) => prev + 1);
 
-            uploadRecordingData(
-              assessmentId,
-              chunk,
-              "video",
-              currentIndex,
-              startTimeRef.current || Date.now(),
-              segmentIdRef.current || undefined
+            trackUpload(
+              uploadRecordingData(
+                assessmentId,
+                chunk,
+                "video",
+                currentIndex,
+                startTimeRef.current || Date.now(),
+                segmentIdRef.current || undefined
+              )
             );
           },
           onScreenshot: (screenshot) => {
             // Upload screenshot
             setScreenshotCount((prev) => prev + 1);
-            uploadRecordingData(
-              assessmentId,
-              screenshot,
-              "screenshot",
-              undefined,
-              Date.now(),
-              segmentIdRef.current || undefined
+            trackUpload(
+              uploadRecordingData(
+                assessmentId,
+                screenshot,
+                "screenshot",
+                undefined,
+                Date.now(),
+                segmentIdRef.current || undefined
+              )
             );
           },
           onError: (err) => {
@@ -561,24 +674,69 @@ export function ScreenRecordingProvider({
       setState("error");
       return false;
     }
-  }, [isSupported, cleanup, handleStreamStopped, assessmentId]);
+  }, [isSupported, cleanup, handleStreamStopped, assessmentId, trackUpload]);
+
+  // Stop the MediaRecorder and await all pending chunk uploads WITHOUT
+  // tearing down streams or marking the segment complete. This must run
+  // before /api/assessment/finalize — once that endpoint flips status to
+  // COMPLETED, /api/recording rejects further uploads with a 400, which
+  // drops the final in-flight video chunk (the last seconds of the defense
+  // call). Teardown is left for stopRecording() so the caller can leave
+  // the streams alive and retry finalize on failure without re-prompting
+  // for screen-share consent.
+  const flushFinalChunk = useCallback(async (): Promise<void> => {
+    if (flushedRef.current) return;
+    flushedRef.current = true;
+
+    const recorder = videoRecorderRef.current;
+    if (recorder) {
+      // stopAndWait resolves after the final ondataavailable + onstop have
+      // fired — so the per-chunk upload (via the onDataAvailable callback)
+      // has been enqueued into pendingUploadsRef by the time this awaits.
+      const finalBlob = await recorder.stopAndWait();
+      videoRecorderRef.current = null;
+
+      if (finalBlob && finalBlob.size > 0) {
+        trackUpload(
+          uploadRecordingData(
+            assessmentId,
+            finalBlob,
+            "video",
+            chunkIndexRef.current,
+            startTimeRef.current || Date.now(),
+            segmentIdRef.current || undefined
+          )
+        );
+      }
+    }
+
+    // Await all in-flight uploads (final chunk + any still-pending earlier
+    // chunks/screenshots). allSettled so a single failed upload doesn't
+    // reject and block finalize — failures are already logged by uploadRecordingData.
+    await Promise.allSettled([...pendingUploadsRef.current]);
+  }, [assessmentId, trackUpload]);
 
   const stopRecording = useCallback(() => {
-    // Stop and upload final video chunk
-    if (videoRecorderRef.current) {
+    // Skip the stop+upload path if flushFinalChunk already ran. This keeps
+    // the public API unchanged for callers who call stopRecording on its
+    // own (e.g. error paths), but avoids double-stop after flushFinalChunk.
+    if (!flushedRef.current && videoRecorderRef.current) {
       const finalBlob = videoRecorderRef.current.stop();
       if (finalBlob && finalBlob.size > 0) {
-        uploadRecordingData(
-          assessmentId,
-          finalBlob,
-          "video",
-          chunkIndexRef.current,
-          startTimeRef.current || Date.now(),
-          segmentIdRef.current || undefined
+        trackUpload(
+          uploadRecordingData(
+            assessmentId,
+            finalBlob,
+            "video",
+            chunkIndexRef.current,
+            startTimeRef.current || Date.now(),
+            segmentIdRef.current || undefined
+          )
         );
       }
       videoRecorderRef.current = null;
     }
+    flushedRef.current = false;
 
     // Mark segment as completed in database
     if (segmentIdRef.current) {
@@ -587,15 +745,19 @@ export function ScreenRecordingProvider({
     }
 
     cleanup();
-    setState("idle");
+    // "ended" signals deliberate finalization — distinct from "idle" (never started)
+    // so the guard doesn't re-prompt for recording consent while the user is
+    // navigating away to /results.
+    setState("ended");
     sessionStorage.removeItem(`screen-recording-${assessmentId}`);
-  }, [cleanup, assessmentId]);
+  }, [cleanup, assessmentId, trackUpload]);
 
   const retryRecording = useCallback(async (): Promise<boolean> => {
     setState("idle");
     setPermissionState("prompt");
     setWebcamState("idle");
     setError(null);
+    setPermissionBlock(null);
     return startRecording();
   }, [startRecording]);
 
@@ -627,8 +789,9 @@ export function ScreenRecordingProvider({
     sessionLoadStartedRef.current = true;
 
     async function loadSession() {
-      // In E2E test mode or when screen recording is skipped, auto-start a fake recording session
-      if (shouldSkipScreenRecording()) {
+      // In E2E test mode, when screen recording is skipped, or for the
+      // designated demo user, auto-start a fake recording session.
+      if (bypassRecording || shouldSkipScreenRecording()) {
         try {
           const sessionResult = await startFakeRecordingSession(assessmentId);
           segmentIdRef.current = sessionResult.segmentId;
@@ -719,10 +882,12 @@ export function ScreenRecordingProvider({
     webcamState,
     webcamStream,
     sessionLoaded,
+    permissionBlock,
     audioMixer: audioMixerRef.current,
     startRecording,
     stopRecording,
     retryRecording,
+    flushFinalChunk,
   };
 
   // Don't render children until session is loaded to avoid flash of content

--- a/src/lib/core/demo-reset.ts
+++ b/src/lib/core/demo-reset.ts
@@ -1,0 +1,73 @@
+import { AssessmentStatus, type PrismaClient } from "@prisma/client";
+
+export const DEMO_USER_EMAIL = "demo@test.com";
+export const DEMO_ASSESSMENT_ID = "demo-assessment";
+export const DEMO_COMPLETED_ASSESSMENT_ID = "demo-completed-assessment";
+
+export interface ResetDemoResult {
+  assessmentId: string;
+  status: AssessmentStatus;
+  welcomeUrl: string;
+  resultsUrl: string;
+}
+
+/**
+ * Wipe and recreate the fresh live-demo assessment.
+ *
+ * Cascading deletes on Assessment remove all chat messages, conversations,
+ * recordings, voice sessions, api call logs, etc. The new row starts at
+ * WELCOME so the walkthrough begins on the intro screen; the 90-min timer
+ * doesn't start until the candidate clicks "Start Simulation". Leaves
+ * `demo-completed-assessment` untouched so the polished results demo is
+ * unaffected.
+ *
+ * Callers: scripts/demo-reset.ts (CLI) and /api/demo/reset (admin HTTP).
+ */
+export async function resetDemoAssessment(
+  prisma: PrismaClient
+): Promise<ResetDemoResult> {
+  const user = await prisma.user.findUnique({
+    where: { email: DEMO_USER_EMAIL },
+  });
+  if (!user) {
+    throw new Error(
+      `Demo user ${DEMO_USER_EMAIL} not found. Seed the database first.`
+    );
+  }
+
+  const existing = await prisma.assessment.findUnique({
+    where: { id: DEMO_ASSESSMENT_ID },
+    select: { scenarioId: true },
+  });
+
+  // Preserve the scenario from the existing assessment when possible — that's
+  // what the seed originally wired up. Fall back to any scenario so this stays
+  // runnable on a fresh DB where the demo row somehow never existed.
+  const scenarioId =
+    existing?.scenarioId ??
+    (await prisma.scenario.findFirst({ select: { id: true } }))?.id;
+  if (!scenarioId) {
+    throw new Error("No scenarios exist. Seed the database first.");
+  }
+
+  if (existing) {
+    await prisma.assessment.delete({ where: { id: DEMO_ASSESSMENT_ID } });
+  }
+
+  await prisma.assessment.create({
+    data: {
+      id: DEMO_ASSESSMENT_ID,
+      userId: user.id,
+      scenarioId,
+      status: AssessmentStatus.WELCOME,
+      workingStartedAt: null,
+    },
+  });
+
+  return {
+    assessmentId: DEMO_ASSESSMENT_ID,
+    status: AssessmentStatus.WELCOME,
+    welcomeUrl: `/assessments/${DEMO_ASSESSMENT_ID}/welcome`,
+    resultsUrl: `/assessments/${DEMO_COMPLETED_ASSESSMENT_ID}/results`,
+  };
+}

--- a/src/lib/core/env.ts
+++ b/src/lib/core/env.ts
@@ -16,6 +16,9 @@ export const env = createEnv({
       .enum(["true", "false"])
       .optional()
       .transform((val) => val === "true"),
+    // Comma-separated list of user IDs that bypass screen recording for demos.
+    // Server-only so the allowlist isn't shipped to the browser.
+    DEMO_USER_IDS: z.string().optional(),
   },
   client: {
     NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
@@ -46,6 +49,7 @@ export const env = createEnv({
     NEXT_PUBLIC_E2E_TEST_MODE: process.env.NEXT_PUBLIC_E2E_TEST_MODE,
     NEXT_PUBLIC_SKIP_SCREEN_RECORDING:
       process.env.NEXT_PUBLIC_SKIP_SCREEN_RECORDING,
+    DEMO_USER_IDS: process.env.DEMO_USER_IDS,
   },
   skipValidation: !!process.env.SKIP_ENV_VALIDATION,
   emptyStringAsUndefined: true,
@@ -105,4 +109,20 @@ export function shouldAllowTestModeRecording(): boolean {
       env.NEXT_PUBLIC_SKIP_SCREEN_RECORDING === true ||
       env.NEXT_PUBLIC_E2E_TEST_MODE === true)
   );
+}
+
+/**
+ * Check whether a given user ID belongs to a designated demo account that
+ * bypasses screen recording (for live product demos). Server-only — the
+ * allowlist is not exposed to the browser. Works in any NODE_ENV.
+ */
+export function isDemoUser(userId: string | null | undefined): boolean {
+  if (!userId) return false;
+  const raw = env.DEMO_USER_IDS ?? "";
+  if (!raw) return false;
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .includes(userId);
 }

--- a/src/lib/media/video-recorder.ts
+++ b/src/lib/media/video-recorder.ts
@@ -203,6 +203,49 @@ export class VideoRecorder {
     return null;
   }
 
+  // Stop recording and wait until the final `ondataavailable` + `onstop`
+  // events have fired. Unlike `stop()`, the returned blob includes the
+  // buffered data flushed by MediaRecorder.stop() — so callers who await
+  // this can be sure the per-chunk upload fired by `onDataAvailable` has
+  // been enqueued before they continue.
+  stopAndWait(): Promise<Blob | null> {
+    return new Promise((resolve) => {
+      this.stopScreenshotCapture();
+
+      const mr = this.mediaRecorder;
+      if (!mr || mr.state === "inactive") {
+        const mimeType =
+          mr?.mimeType || this.config.mimeType || "video/webm";
+        const blob =
+          this.recordedChunks.length > 0
+            ? new Blob(this.recordedChunks, { type: mimeType })
+            : null;
+        this.recordedChunks = [];
+        this.isRecording = false;
+        this.stream = null;
+        resolve(blob);
+        return;
+      }
+
+      // Chain onto the existing onstop handler set in start().
+      const existingOnStop = mr.onstop;
+      mr.onstop = (evt) => {
+        if (existingOnStop) existingOnStop.call(mr, evt);
+        const mimeType = mr.mimeType || this.config.mimeType || "video/webm";
+        const blob =
+          this.recordedChunks.length > 0
+            ? new Blob(this.recordedChunks, { type: mimeType })
+            : null;
+        this.recordedChunks = [];
+        resolve(blob);
+      };
+
+      mr.stop();
+      this.isRecording = false;
+      this.stream = null;
+    });
+  }
+
   // Pause recording
   pause(): void {
     if (this.mediaRecorder && this.mediaRecorder.state === "recording") {


### PR DESCRIPTION
## Summary

- Adds `DEMO_USER_IDS` allowlist + `isDemoUser()` helper so designated accounts skip screen/webcam/mic capture on the assessment work page — needed for live product demos where the recorder competes with the presenter's screen share.
- Threads a `bypassRecording` prop end-to-end through the screen-recording wrapper/guard/context. Server-side gate on `/api/recording/session` so `testMode` uploads survive outside dev for demo users only.
- Ships the demo state refresh: `/api/demo/reset`, admin "Reset Demo" button, `npm run demo:reset` script. Seed creates `demo@test.com` with a fixed `demo-user` id and a polished `demo-completed-assessment` for the recruiter-view walkthrough.
- **Bundled fix:** `WorkPageClient` now `await flushFinalChunk()` *before* `/api/assessment/finalize`. Previously, once the assessment flipped to `COMPLETED`, `/api/recording` 400s and the tail of the recording (end of the defense call) was silently lost.

## Test plan

- [ ] Set `DEMO_USER_IDS=demo-user` and sign in as `demo@test.com` → `/assessments/demo-assessment/work` renders with no screen-recording prompt and no webcam preview.
- [ ] Sign in as `user@test.com` → `/work` still shows the recording prompt (allowlist is exclusive).
- [ ] Finish a non-demo assessment and confirm the final chunk lands in storage (compare chunk count pre/post fix).
- [ ] Click **Reset Demo** in `/admin` → `demo-assessment` returns to `WELCOME` and conversations are cleared.
- [ ] `npm run demo:reset` works from CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)