### PR TITLE
fix(simulations): recover resources when client fetch times out

### DIFF
--- a/src/app/[locale]/recruiter/simulations/new/client.tsx
+++ b/src/app/[locale]/recruiter/simulations/new/client.tsx
@@ -77,6 +77,7 @@ type PreviewData = {
   selectedTask: TaskChoice | null;
   coworkers: CoworkerBuilderData[];
   resources: ScenarioResource[];
+  resourcesFailed?: boolean;
   language: "en" | "es";
 };
 
@@ -520,6 +521,7 @@ export function RecruiterScenarioBuilderClient({ uiLocale }: RecruiterScenarioBu
           simulationDepth,
           resources: previewData.resources.length > 0 ? previewData.resources : undefined,
           language: previewData.language,
+          creationLogId: creationLogIdRef.current ?? undefined,
           // repoUrl is intentionally omitted - it will be set by repo provisioning
         }),
       });
@@ -697,8 +699,13 @@ export function RecruiterScenarioBuilderClient({ uiLocale }: RecruiterScenarioBu
       const coworkersData = coworkersJson.data || coworkersJson;
       const coworkers: CoworkerBuilderData[] = coworkersData.coworkers || [];
 
-      // Generate resources based on task + company context
+      // Generate resources based on task + company context.
+      // If the client-side fetch fails (timeout, network) the backend may still
+      // complete the step — the server-side fallback in POST /api/recruiter/simulations
+      // will recover the output by creationLogId. But we surface it as a warning
+      // so the user knows to verify or retry rather than shipping empty.
       let resources: ScenarioResource[] = [];
+      let resourceGenerationWarning = false;
       try {
         const resourcesResponse = await fetch("/api/recruiter/simulations/generate-resources", {
           method: "POST",
@@ -719,10 +726,12 @@ export function RecruiterScenarioBuilderClient({ uiLocale }: RecruiterScenarioBu
           const resourcesData = resourcesJson.data || resourcesJson;
           resources = resourcesData.resources || [];
         } else {
-          logger.warn("Resource generation failed, continuing without resources");
+          logger.error("Resource generation failed", { status: resourcesResponse.status });
+          resourceGenerationWarning = true;
         }
       } catch (resourceErr) {
-        logger.warn("Resource generation error, continuing without resources", { err: String(resourceErr) });
+        logger.error("Resource generation error", { err: String(resourceErr) });
+        resourceGenerationWarning = true;
       }
 
       // Set up preview data
@@ -735,6 +744,7 @@ export function RecruiterScenarioBuilderClient({ uiLocale }: RecruiterScenarioBu
         selectedTask: null, // User must select
         coworkers,
         resources,
+        resourcesFailed: resourceGenerationWarning,
         language,
       });
 
@@ -1240,6 +1250,17 @@ export function RecruiterScenarioBuilderClient({ uiLocale }: RecruiterScenarioBu
             </p>
           </div>
         </div>
+
+        {previewData.resourcesFailed && previewData.resources.length === 0 && (
+          <div className="border-b bg-amber-50 px-6 py-3 dark:bg-amber-950/30">
+            <div className="mx-auto flex max-w-6xl items-start gap-2 text-sm">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+              <p className="text-amber-900 dark:text-amber-200">
+                Resource generation didn&apos;t finish in time. The simulation will be created without reference materials — you can retry by going back, or proceed and add them later.
+              </p>
+            </div>
+          </div>
+        )}
 
         {/* Two-column body */}
         <div className="flex-1 overflow-y-auto px-6 py-6">

--- a/src/app/api/recruiter/simulations/route.ts
+++ b/src/app/api/recruiter/simulations/route.ts
@@ -89,7 +89,24 @@ export async function POST(request: Request) {
   // Validate request body using Zod schema
   const validated = await validateRequest(request, ScenarioCreateSchema);
   if ("error" in validated) return validated.error;
-  const { name, companyName, companyDescription, taskDescription, repoUrl, techStack, targetLevel, archetypeId, simulationDepth, resources, language } = validated.data;
+  const { name, companyName, companyDescription, taskDescription, repoUrl, techStack, targetLevel, archetypeId, simulationDepth, resources, language, creationLogId } = validated.data;
+
+  // Fallback: if the client didn't send resources but we have a creation log,
+  // look up the completed generate_resources step and use its output.
+  // This closes a race where the client's fetch to generate-resources times
+  // out but the backend step eventually succeeds and persists its output.
+  let finalResources = resources;
+  if ((!finalResources || finalResources.length === 0) && creationLogId) {
+    const step = await db.simulationGenerationStep.findFirst({
+      where: { creationLogId, stepName: "generate_resources", status: "completed" },
+      orderBy: { createdAt: "desc" },
+    });
+    const recovered = (step?.outputData as { resources?: unknown } | null)?.resources;
+    if (Array.isArray(recovered) && recovered.length > 0) {
+      logger.info("Recovered resources from generate_resources step", { creationLogId, count: recovered.length });
+      finalResources = recovered as typeof resources;
+    }
+  }
 
   // Create scenario with createdById set to current user and isPublished true
   try {
@@ -104,7 +121,7 @@ export async function POST(request: Request) {
         targetLevel,
         simulationDepth,
         archetypeId,
-        resources: resources as unknown as import("@prisma/client").Prisma.InputJsonValue,
+        resources: finalResources as unknown as import("@prisma/client").Prisma.InputJsonValue,
         language, // Persist the language field
         isPublished: true, // Recruiter scenarios are always active
         createdById: user.id, // Set ownership to current user

--- a/src/lib/schemas/api.ts
+++ b/src/lib/schemas/api.ts
@@ -76,6 +76,7 @@ export const ScenarioCreateSchema = z.object({
   isPublished: z.boolean().optional().default(false),
   resources: z.array(ScenarioResourceSchema).optional(),
   language: z.string().optional().default("en"),
+  creationLogId: z.string().optional(),
 });
 export type ScenarioCreate = z.infer<typeof ScenarioCreateSchema>;
 


### PR DESCRIPTION
## Summary

- `POST /api/recruiter/simulations` now accepts optional `creationLogId` and falls back to the completed `generate_resources` step's `outputData.resources` when the client sends no resources. Closes the race where long resource generations (>60s) time out the client fetch even though the backend step completes and logs valid output.
- Client sends `creationLogId` and shows an amber warning banner on the preview when generation didn't finish, instead of silently continuing with an empty array.
- Bumped client-side `logger.warn` → `logger.error` on both failure paths so the signal reaches monitoring.

Found this investigating simulation log `cmoakkcdx0003udlonu00t1jk`, where all 4 steps logged `completed` but `scenario.resources` was `null`. Timeline: the scenario was created at 21:35:40, 28 seconds before `generate_resources` finished at 21:36:08 (128s total, 2 attempts). The resources existed in `SimulationGenerationStep.outputData` the whole time.

That specific scenario (`cmoaknkz2000fudlopdiafn3q`) has already been recovered in the DB.

## Test plan

- [ ] Create a simulation end-to-end via `/recruiter/simulations/new` and confirm resources persist on the resulting scenario.
- [ ] Force a slow `generate_resources` (throttle network or increase prompt) and verify the server-side fallback picks up the step output once `POST /api/recruiter/simulations` fires.
- [ ] Confirm the amber banner renders on the preview when resource generation actually fails (e.g. 500 from the endpoint) and that creation still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)