### PR TITLE
fix(simulations): retry transient network failures during creation

### DIFF
--- a/src/app/[locale]/recruiter/simulations/new/client.tsx
+++ b/src/app/[locale]/recruiter/simulations/new/client.tsx
@@ -41,6 +41,7 @@ import {
   SheetDescription,
 } from "@/components/ui/sheet";
 import { createLogger } from "@/lib/core";
+import { fetchWithRetry } from "@/lib/api";
 
 const logger = createLogger("client:recruiter:new-simulation");
 
@@ -222,7 +223,7 @@ export function RecruiterScenarioBuilderClient({ uiLocale }: RecruiterScenarioBu
     source: "jd_paste" | "guided";
   }) => {
     try {
-      const res = await fetch("/api/recruiter/simulations/creation-log", {
+      const res = await fetchWithRetry("/api/recruiter/simulations/creation-log", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
@@ -251,7 +252,7 @@ export function RecruiterScenarioBuilderClient({ uiLocale }: RecruiterScenarioBu
     const logId = creationLogIdRef.current;
     if (!logId) return;
     try {
-      await fetch("/api/recruiter/simulations/creation-log", {
+      await fetchWithRetry("/api/recruiter/simulations/creation-log", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ logId, ...data }),
@@ -345,8 +346,12 @@ export function RecruiterScenarioBuilderClient({ uiLocale }: RecruiterScenarioBu
       await generatePreviewContent(parsedData);
 
     } catch (err) {
-      logger.error("Failed to parse job description", { err });
       const errorMsg = err instanceof Error ? err.message : "Failed to analyze job description";
+      logger.error("Simulation creation failed (entry path)", {
+        err: String(err),
+        message: errorMsg,
+        stack: err instanceof Error ? err.stack : undefined,
+      });
       await updateLog({
         status: "FAILED",
         failedStep: "parse_jd",
@@ -507,7 +512,7 @@ export function RecruiterScenarioBuilderClient({ uiLocale }: RecruiterScenarioBu
         : previewData.selectedTask.option?.description || "Complete a work challenge";
 
       // Step 2: Create scenario (repoUrl omitted - will be set by provisioning)
-      const scenarioResponse = await fetch("/api/recruiter/simulations", {
+      const scenarioResponse = await fetchWithRetry("/api/recruiter/simulations", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -537,7 +542,7 @@ export function RecruiterScenarioBuilderClient({ uiLocale }: RecruiterScenarioBu
 
       // Step 3: Create coworkers
       const coworkerPromises = previewData.coworkers.map(async (coworker) => {
-        const response = await fetch(`/api/recruiter/simulations/${scenario.id}/coworkers`, {
+        const response = await fetchWithRetry(`/api/recruiter/simulations/${scenario.id}/coworkers`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -68,6 +68,40 @@ export function buildTracedHeaders(
  *   }
  * }
  */
+/**
+ * fetch() wrapper that retries transient network failures.
+ *
+ * Retries only on TypeError (DNS/connection refused, dev-server HMR reload,
+ * browser-level abort). HTTP error responses (4xx/5xx) are returned as-is so
+ * real server bugs still surface.
+ *
+ * Why: Long-running user actions (e.g. simulation creation) occasionally hit
+ * a "Failed to fetch" when the dev server reloads or the network blips. A
+ * couple of short retries hides the noise without masking real failures.
+ */
+export async function fetchWithRetry(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  options?: { retries?: number; backoffMs?: number[] }
+): Promise<Response> {
+  const retries = options?.retries ?? 2;
+  const backoff = options?.backoffMs ?? [300, 900];
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fetch(input, init);
+    } catch (err) {
+      if (!(err instanceof TypeError)) throw err;
+      lastErr = err;
+      if (attempt < retries) {
+        const delay = backoff[attempt] ?? backoff[backoff.length - 1] ?? 300;
+        await new Promise((r) => setTimeout(r, delay));
+      }
+    }
+  }
+  throw lastErr;
+}
+
 export async function api<T>(endpoint: string, options?: ApiOptions): Promise<T> {
   const response = await fetch(endpoint, {
     method: options?.method ?? "GET",

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -7,6 +7,6 @@
  * - validation: Request body validation using Zod schemas
  */
 
-export { api, ApiClientError, buildTracedHeaders } from "./client";
+export { api, ApiClientError, buildTracedHeaders, fetchWithRetry } from "./client";
 export { success, error, validationError } from "./response";
 export { validateRequest } from "./validation";


### PR DESCRIPTION
## Summary

- Adds `fetchWithRetry` in [src/lib/api/client.ts](src/lib/api/client.ts) — wraps `fetch()` with 2 retries (300ms / 900ms) **only** on `TypeError` (network-level failure: dev-server HMR reload, DNS, browser abort). HTTP 4xx/5xx responses pass through untouched so real bugs still surface.
- Wires it into the simulation save path in [src/app/[locale]/recruiter/simulations/new/client.tsx](src/app/%5Blocale%5D/recruiter/simulations/new/client.tsx): both `creation-log` calls (POST + PATCH), `POST /api/recruiter/simulations`, and per-coworker `POST`s.

## Why

Recruiters occasionally hit a "Failed to fetch" mid-save and have to click "Try again" (the request never reached the server). The simulation `POST` itself is just a DB insert, so the failure is a network-level abort, not a server error — a couple of short retries hides that noise without masking real failures.

## Scope notes

- Long-running LLM calls (`parse-jd`, `generate-task`, `generate-coworkers`, `generate-resources`) and the fire-and-forget `avatar/generate` + `provision-repo` calls are intentionally **not** wrapped here. They're more vulnerable to HMR than the save itself, but each retry burns LLM credits — wanted to keep this PR focused.
- Retries on `TypeError` only, so a real 500 from the API surfaces immediately instead of being delayed by ~1.2s.

## Test plan

- [ ] Manual: create a simulation end-to-end on `/recruiter/simulations/new` — happy path completes (no extra latency).
- [ ] Manual: with devtools "Offline" toggled briefly during the save, the request retries instead of failing instantly.
- [ ] `npm run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)