### PR TITLE
fix(tests): stub stale mocks so CI unit-tests stop failing

### DIFF
--- a/src/app/api/assessment/report/route.test.ts
+++ b/src/app/api/assessment/report/route.test.ts
@@ -45,6 +45,13 @@ vi.mock("@/lib/external", () => ({
   isEmailServiceConfigured: vi.fn().mockReturnValue(false),
 }));
 
+// Candidate narrative makes a Gemini call and writes to db.assessmentApiCall via
+// logAICall. Stubbing it lets the route exercise its happy path without needing
+// to mock the AI SDK or extend the db mock with the assessmentApiCall model.
+vi.mock("@/lib/analysis/candidate-narrative", () => ({
+  generateCandidateNarrative: vi.fn().mockResolvedValue(null),
+}));
+
 // Sample video evaluation output in v3 (RubricAssessmentOutput) format
 const sampleVideoEvaluationOutput = {
   evaluationVersion: "3.0.0",

--- a/src/app/api/recording/session/route.test.ts
+++ b/src/app/api/recording/session/route.test.ts
@@ -54,6 +54,7 @@ vi.mock("@/server/db", () => ({
 const mockIsE2ETestMode = vi.fn();
 vi.mock("@/lib/core/env", () => ({
   shouldAllowTestModeRecording: () => mockIsE2ETestMode(),
+  isDemoUser: () => false,
   env: {
     DATABASE_URL: "postgresql://localhost:5432/test",
     DIRECT_URL: "postgresql://localhost:5432/test",


### PR DESCRIPTION
## Summary

CI's unit-tests job has been red on every open PR (and on main itself) since PRs #397 and #398 merged. Vercel deployments are unaffected — both production and preview show ✅. This PR unblocks GitHub Actions.

Two recently-merged PRs added new dependencies inside hot paths covered by existing tests, but the test mocks weren't extended:

**`src/app/api/assessment/report/route.test.ts`** — 3 tests, all `expected 200, got 500`
- #398 wired `generateCandidateNarrative` into `generateOrFetchReport`. That function calls `logAICall`, which writes to `db.assessmentApiCall` — a model the test's `db` mock doesn't expose. Result: `TypeError: Cannot read properties of undefined (reading 'create')` → caught → 500.
- Fix: stub `@/lib/analysis/candidate-narrative` to resolve `null` (the route already handles the null path gracefully).

**`src/app/api/recording/session/route.test.ts`** — 1 test, `expected 403, got 500`
- #397 added an `isDemoUser` import to the route. The test's `vi.mock("@/lib/core/env", …)` only stubs `shouldAllowTestModeRecording` and `env`, leaving `isDemoUser` undefined. Calling `undefined(…)` threw → 500.
- Fix: add `isDemoUser: () => false` to the env mock.

Diff is **+8 lines** total across the two files.

## Test plan

- [x] `npx vitest run src/app/api/assessment/report/route.test.ts src/app/api/recording/session/route.test.ts` → 36/36 pass
- [ ] CI `unit-tests` job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)