### PR TITLE
fix(assessment): make finalize idempotent after end_walkthrough transition

### DIFF
--- a/src/app/api/assessment/finalize/route.test.ts
+++ b/src/app/api/assessment/finalize/route.test.ts
@@ -127,14 +127,14 @@ describe("POST /api/assessment/finalize", () => {
     expect(data.error).toBe("Unauthorized to modify this assessment");
   });
 
-  it("should return 400 when assessment is not in WORKING status", async () => {
+  it("should return 400 when assessment is in WELCOME status", async () => {
     mockAuth.mockResolvedValue({
       user: { id: "user-123" },
     });
     mockAssessmentFindUnique.mockResolvedValue({
       id: "test-id",
       userId: "user-123",
-      status: AssessmentStatus.WELCOME, // Wrong status
+      status: AssessmentStatus.WELCOME, // Candidate hasn't started
       startedAt: new Date(),
       scenario: { taskDescription: "Test task" },
       recordings: [],
@@ -149,7 +149,7 @@ describe("POST /api/assessment/finalize", () => {
     expect(response.status).toBe(400);
 
     const data = await response.json();
-    expect(data.error).toContain("Must be in WORKING status");
+    expect(data.error).toContain("WELCOME");
   });
 
   it("should finalize assessment and return timing info", async () => {
@@ -216,15 +216,19 @@ describe("POST /api/assessment/finalize", () => {
     expect(data.error).toBe("Failed to finalize assessment");
   });
 
-  it("should not finalize if already completed", async () => {
+  it("should be idempotent when already COMPLETED — return success without re-stamping completedAt", async () => {
+    const startedAt = new Date("2024-01-01T10:00:00Z");
+    const originalCompletedAt = new Date("2024-01-01T10:30:00Z");
+
     mockAuth.mockResolvedValue({
       user: { id: "user-123" },
     });
     mockAssessmentFindUnique.mockResolvedValue({
       id: "test-id",
       userId: "user-123",
-      status: AssessmentStatus.COMPLETED, // Already completed
-      startedAt: new Date(),
+      status: AssessmentStatus.COMPLETED, // Already flipped by end_walkthrough transition
+      startedAt,
+      completedAt: originalCompletedAt,
       scenario: { taskDescription: "Test task" },
       recordings: [],
     });
@@ -235,10 +239,14 @@ describe("POST /api/assessment/finalize", () => {
     });
 
     const response = await POST(request);
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(200);
 
     const data = await response.json();
-    expect(data.error).toContain("COMPLETED");
+    expect(data.success).toBe(true);
+    expect(data.data.assessment.status).toBe(AssessmentStatus.COMPLETED);
+    expect(data.data.timing.completedAt).toBe(originalCompletedAt.toISOString());
+    // Status flip skipped — no DB update for the assessment row
+    expect(mockAssessmentUpdate).not.toHaveBeenCalled();
   });
 
   it("should trigger video assessment when recording exists", async () => {

--- a/src/app/api/assessment/finalize/route.ts
+++ b/src/app/api/assessment/finalize/route.ts
@@ -42,6 +42,7 @@ export async function POST(request: Request) {
         status: true,
         startedAt: true,
         workingStartedAt: true,
+        completedAt: true,
         codeReview: true,
         scenario: {
           select: {
@@ -66,10 +67,16 @@ export async function POST(request: Request) {
       return error("Unauthorized to modify this assessment", 403);
     }
 
-    // Check that assessment is in WORKING status (after PR submission, before defense)
-    if (assessment.status !== AssessmentStatus.WORKING) {
+    // Allow finalize from WORKING (legacy direct path) or COMPLETED (the new
+    // flow flips to COMPLETED via the end_walkthrough transition just before
+    // calling finalize for the post-assessment pipeline). Reject WELCOME and
+    // any other phases — candidate hasn't progressed far enough to finalize.
+    if (
+      assessment.status !== AssessmentStatus.WORKING &&
+      assessment.status !== AssessmentStatus.COMPLETED
+    ) {
       return error(
-        `Cannot finalize assessment in ${assessment.status} status. Must be in WORKING status.`,
+        `Cannot finalize assessment in ${assessment.status} status.`,
         400
       );
     }
@@ -77,24 +84,39 @@ export async function POST(request: Request) {
     // Calculate total duration (use workingStartedAt if available, else fall back to startedAt)
     const now = new Date();
     const timerStart = assessment.workingStartedAt ?? assessment.startedAt;
-    const totalDurationMs = now.getTime() - timerStart.getTime();
+    const alreadyCompleted = assessment.status === AssessmentStatus.COMPLETED;
+    const completedAt = alreadyCompleted
+      ? (assessment.completedAt ?? now)
+      : now;
+    const totalDurationMs = completedAt.getTime() - timerStart.getTime();
     const totalDurationSeconds = Math.floor(totalDurationMs / 1000);
 
-    // Update assessment status to COMPLETED
-    const updatedAssessment = await db.assessment.update({
-      where: { id: assessmentId },
-      data: {
-        status: AssessmentStatus.COMPLETED,
-        completedAt: now,
-      },
-      select: {
-        id: true,
-        status: true,
-        startedAt: true,
-        completedAt: true,
-        codeReview: true,
-      },
-    });
+    // Idempotent: when status is already COMPLETED (typical after the
+    // end_walkthrough transition just stamped it), skip the status flip and
+    // preserve the original completedAt. Side-effects below are upsert-based
+    // so they're safe to re-run.
+    const updatedAssessment = alreadyCompleted
+      ? {
+          id: assessment.id,
+          status: assessment.status,
+          startedAt: assessment.startedAt,
+          completedAt,
+          codeReview: assessment.codeReview,
+        }
+      : await db.assessment.update({
+          where: { id: assessmentId },
+          data: {
+            status: AssessmentStatus.COMPLETED,
+            completedAt: now,
+          },
+          select: {
+            id: true,
+            status: true,
+            startedAt: true,
+            completedAt: true,
+            codeReview: true,
+          },
+        });
 
     // Merge recording chunks and trigger video assessment (async, non-blocking)
     // The merge + Gemini upload + ACTIVE polling can take minutes for large videos,
@@ -162,7 +184,7 @@ export async function POST(request: Request) {
       assessment: updatedAssessment,
       timing: {
         startedAt: assessment.startedAt.toISOString(),
-        completedAt: now.toISOString(),
+        completedAt: completedAt.toISOString(),
         totalDurationSeconds,
       },
       videoAssessment: {


### PR DESCRIPTION
## Summary

- After the walkthrough call, the client first calls `end_walkthrough` (which flips status to `COMPLETED`) and then calls `/api/assessment/finalize` for the post-assessment pipeline. Finalize was rejecting any status ≠ `WORKING` with a 400, leaving candidates stuck on `/work` — video evaluation, profile-photo generation, and the redirect to `/results` never happened. Subsequent call attempts then hit "Assessment is completed" from `/api/call/token`, surfacing a "Call Failed" banner on the work page.
- Finalize now accepts `COMPLETED` in addition to `WORKING`. On the COMPLETED path it skips the status flip and preserves the original `completedAt`, still running the side-effects (`triggerVideoAssessment` and `generateProfilePhoto` are both upsert-based and safe to re-run).
- The transition route's own header comment already described this handoff ("the post-assessment pipeline still lives in /api/assessment/finalize which the client calls next") — finalize was just never updated to accept it.

## Why

User report: "After finalizing my assessment it brought me back here." Console log: `[ERROR] [client:app:work-page] "Failed to finalize assessment"` from `work/client.tsx:357`. Root cause traced to the WORKING-only status check in `finalize/route.ts`.

## Reviewer notes

- Idempotency relies on `triggerVideoAssessment` (uses `db.videoAssessment.upsert` and short-circuits on `PROCESSING`/`COMPLETED`) and `generateProfilePhoto` (uses `upsert: true` for storage). No new dedupe logic added.
- WELCOME and the in-progress phases (REVIEW_MATERIALS / KICKOFF_CALL / WALKTHROUGH_CALL) are still rejected — only WORKING and COMPLETED are accepted.
- I did not run a full browser walkthrough: the working tree at this snapshot has unrelated in-progress refactor changes (missing `AssessmentTransitionSchema` and `PacingNudgeSchema` exports, deliverable-column cleanup) that prevent the dev server from compiling the transition route this bug runs through. Verified via the route's unit tests instead.

## Test plan

- [x] `npx vitest run src/app/api/assessment/finalize/route.test.ts` — 16/16 pass, including a new test asserting the idempotent COMPLETED path returns 200, preserves `completedAt`, and skips the DB update.
- [ ] Manual: complete a walkthrough call, click Finalize, confirm redirect to `/results` and that `videoAssessment` + profile photo are triggered exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)