### PR TITLE
fix(recording): make merged WebM seekable in admin playback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "superjson": "^2.2.1",
         "tailwind-merge": "^3.3.0",
         "tailwindcss-animate": "^1.0.7",
+        "ts-ebml": "^3.0.2",
         "xlsx": "^0.18.5",
         "zod": "^3.24.2"
       },
@@ -8121,6 +8122,14 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -9410,6 +9419,40 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
+    "node_modules/ebml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ebml/-/ebml-3.0.0.tgz",
+      "integrity": "sha512-Q6C1u4/TX1nYipT9HNIopp95YyyyI0zs1GXdNRKO7XL7k+oo+ZtDc1CaJjpCdmlLxWsnlKBOXJCXkYU0K/Anlg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "^0.1.1",
+        "debug": "~3.1.0"
+      },
+      "engines": {
+        "node": ">= 6.4"
+      }
+    },
+    "node_modules/ebml-block": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ebml-block/-/ebml-block-1.1.2.tgz",
+      "integrity": "sha512-HgNlIsRFP6D9VKU5atCeHRJY7XkJP8bOe8yEhd8NB7B3b4++VWTyauz6g650iiPmLfPLGlVpoJmGSgMfXDYusg==",
+      "license": "MIT"
+    },
+    "node_modules/ebml/node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ebml/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -10247,6 +10290,15 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -11647,6 +11699,12 @@
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
     },
+    "node_modules/int64-buffer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.0.tgz",
+      "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -12833,6 +12891,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/matroska-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/matroska-schema/-/matroska-schema-2.1.0.tgz",
+      "integrity": "sha512-6c1oFmDxf4Vc5J5lA+9wO7TKcw5M1w85HfzFhAFT4OuEUuqp/s/jqqC3OKlaWe1YwN5wTThJyTC7iwhyW7kQdg==",
+      "license": "MIT"
     },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
@@ -17709,6 +17773,32 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-ebml": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ts-ebml/-/ts-ebml-3.0.2.tgz",
+      "integrity": "sha512-Br6DA/YbdpsiSQjc0KaF3ASQtkk3MCiA4q5kIA7ptv6adZa/MdYa2TXAXF2bAzRZIMWfyFEC9Gicr3nb51MgDA==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.0.0",
+        "ebml": "^3.0.0",
+        "ebml-block": "^1.1.2",
+        "events": "^3.3.0",
+        "int64-buffer": "^1.0.1",
+        "matroska-schema": "^2.1.0"
+      },
+      "bin": {
+        "ts-ebml": "lib/cli.js"
+      }
+    },
+    "node_modules/ts-ebml/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-interface-checker": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "superjson": "^2.2.1",
     "tailwind-merge": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
+    "ts-ebml": "^3.0.2",
     "xlsx": "^0.18.5",
     "zod": "^3.24.2"
   },

--- a/scripts/backfill-recording-seekability.ts
+++ b/scripts/backfill-recording-seekability.ts
@@ -1,0 +1,102 @@
+/**
+ * Backfill: rewrite existing merged.webm files in Supabase storage so they're
+ * seekable in the browser. MediaRecorder produces WebM without a Duration
+ * element or Cues table, so the previous binary-concat merge produced files
+ * the browser couldn't scrub. This script downloads each merged.webm, runs
+ * it through `makeWebmSeekable`, and re-uploads the fixed version.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-recording-seekability.ts            # dry run, all
+ *   npx tsx scripts/backfill-recording-seekability.ts --apply    # write changes
+ *   npx tsx scripts/backfill-recording-seekability.ts <id> --apply
+ */
+import { db } from "../src/server/db";
+import { supabaseAdmin, STORAGE_BUCKETS } from "../src/lib/external";
+import { makeWebmSeekable } from "../src/lib/media/webm-seekable";
+
+async function processOne(assessmentId: string, apply: boolean) {
+  const path = `${assessmentId}/merged.webm`;
+  const { data, error: dlError } = await supabaseAdmin.storage
+    .from(STORAGE_BUCKETS.RECORDINGS)
+    .download(path);
+
+  if (dlError || !data) {
+    console.log(`  skip ${assessmentId}: download failed (${dlError?.message ?? "no data"})`);
+    return { ok: false };
+  }
+
+  const original = Buffer.from(await data.arrayBuffer());
+  const fixed = await makeWebmSeekable(original);
+
+  if (fixed === original || fixed.length === original.length) {
+    console.log(`  ${assessmentId}: no change (${original.length} bytes)`);
+    return { ok: true, changed: false };
+  }
+
+  console.log(
+    `  ${assessmentId}: ${original.length} -> ${fixed.length} bytes${apply ? " (uploading)" : " (dry-run)"}`
+  );
+
+  if (!apply) return { ok: true, changed: true };
+
+  const { error: upError } = await supabaseAdmin.storage
+    .from(STORAGE_BUCKETS.RECORDINGS)
+    .upload(path, fixed, { contentType: "video/webm", upsert: true });
+
+  if (upError) {
+    console.log(`  upload failed for ${assessmentId}: ${upError.message}`);
+    return { ok: false };
+  }
+
+  // Refresh signed URL on the Recording row so admin playback picks it up
+  const { data: signed } = await supabaseAdmin.storage
+    .from(STORAGE_BUCKETS.RECORDINGS)
+    .createSignedUrl(path, 60 * 60 * 24 * 365);
+
+  if (signed?.signedUrl) {
+    await db.recording.update({
+      where: { id: `${assessmentId}-screen` },
+      data: { storageUrl: signed.signedUrl },
+    });
+  }
+
+  return { ok: true, changed: true };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+  const explicitIds = args.filter((a) => !a.startsWith("--"));
+
+  let assessmentIds: string[];
+  if (explicitIds.length > 0) {
+    assessmentIds = explicitIds;
+  } else {
+    const recordings = await db.recording.findMany({
+      where: { id: { endsWith: "-screen" } },
+      select: { assessmentId: true },
+    });
+    assessmentIds = recordings.map((r) => r.assessmentId);
+  }
+
+  console.log(
+    `Processing ${assessmentIds.length} recording(s) ${apply ? "(APPLY)" : "(DRY RUN — pass --apply to write)"}`
+  );
+
+  let changed = 0;
+  let failed = 0;
+  for (const id of assessmentIds) {
+    const r = await processOne(id, apply);
+    if (!r.ok) failed++;
+    else if (r.changed) changed++;
+  }
+
+  console.log(`\nDone. changed=${changed} failed=${failed} total=${assessmentIds.length}`);
+  await db.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await db.$disconnect();
+  process.exit(1);
+});

--- a/src/app/api/admin/recording/merge/route.ts
+++ b/src/app/api/admin/recording/merge/route.ts
@@ -2,6 +2,7 @@ import { requireAdmin, createLogger } from "@/lib/core";
 import { success, error } from "@/lib/api";
 import { db } from "@/server/db";
 import { supabaseAdmin, STORAGE_BUCKETS } from "@/lib/external";
+import { makeWebmSeekable } from "@/lib/media";
 
 const logger = createLogger("api:admin:recording:merge");
 
@@ -152,7 +153,8 @@ export async function POST(request: Request) {
       return error("All chunk downloads failed", 500);
     }
 
-    const merged = Buffer.concat(chunkBuffers);
+    const concatenated = Buffer.concat(chunkBuffers);
+    const merged = await makeWebmSeekable(concatenated);
 
     // Upload merged file to Supabase
     const mergedPath = `${assessmentId}/merged.webm`;

--- a/src/lib/analysis/video-merge.test.ts
+++ b/src/lib/analysis/video-merge.test.ts
@@ -54,6 +54,13 @@ vi.mock("@/lib/core", () => ({
   }),
 }));
 
+// Mock the WebM seekability rewrite — these tests use minimal byte fixtures
+// that aren't valid full WebM, so we keep merge-logic assertions focused on
+// chunk concatenation rather than ts-ebml's metadata transformation.
+vi.mock("@/lib/media", () => ({
+  makeWebmSeekable: (input: Buffer) => Promise.resolve(new Uint8Array(input)),
+}));
+
 import { mergeRecordingChunks } from "./video-merge";
 
 // Helper: create a fake Blob that works in Node.js tests
@@ -168,8 +175,13 @@ describe("mergeRecordingChunks", () => {
     expect(result.totalSegments).toBe(1);
     expect(result.totalSizeBytes).toBe(chunkData.length);
 
-    // Should NOT upload to Supabase (no merge needed)
-    expect(mockUpload).not.toHaveBeenCalled();
+    // Should still persist a seekable copy to Supabase so the admin player
+    // can scrub immediately, even for single-chunk recordings.
+    expect(mockUpload).toHaveBeenCalledWith(
+      "test-assessment/merged.webm",
+      expect.any(Uint8Array),
+      expect.objectContaining({ contentType: "video/webm", upsert: true })
+    );
     // Should upload to Gemini with correct mimeType
     expect(mockGeminiUpload).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -243,7 +255,7 @@ describe("mergeRecordingChunks", () => {
     // Should upload merged file to Supabase
     expect(mockUpload).toHaveBeenCalledWith(
       "test-assessment/merged.webm",
-      expect.any(Buffer),
+      expect.any(Uint8Array),
       expect.objectContaining({ contentType: "video/webm", upsert: true })
     );
   });

--- a/src/lib/analysis/video-merge.ts
+++ b/src/lib/analysis/video-merge.ts
@@ -12,6 +12,7 @@ import { gemini } from "@/lib/ai/gemini";
 import { db } from "@/server/db";
 import { supabaseAdmin, STORAGE_BUCKETS } from "@/lib/external";
 import { createLogger } from "@/lib/core";
+import { makeWebmSeekable } from "@/lib/media";
 
 const logger = createLogger("lib:analysis:video-merge");
 
@@ -191,7 +192,30 @@ export async function mergeRecordingChunks(
         };
       }
 
-      const buffer = Buffer.from(await downloadData.arrayBuffer());
+      const rawBuffer = Buffer.from(await downloadData.arrayBuffer());
+      const buffer = await makeWebmSeekable(rawBuffer);
+
+      // Persist the seekable version so admin playback can scrub immediately
+      const mergedPath = `${assessmentId}/merged.webm`;
+      const { error: uploadStorageError } = await supabaseAdmin.storage
+        .from(STORAGE_BUCKETS.RECORDINGS)
+        .upload(mergedPath, buffer, {
+          contentType: "video/webm",
+          upsert: true,
+        });
+
+      if (!uploadStorageError) {
+        const { data: signedData } = await supabaseAdmin.storage
+          .from(STORAGE_BUCKETS.RECORDINGS)
+          .createSignedUrl(mergedPath, 60 * 60 * 24 * 365); // 1 year
+        if (signedData?.signedUrl) {
+          await db.recording.update({
+            where: { id: recordingId },
+            data: { storageUrl: signedData.signedUrl },
+          });
+        }
+      }
+
       const uploadResult = await uploadAndWaitForActive(
         new Blob([buffer], { type: "video/webm" }),
         `assessment-${assessmentId}-recording`
@@ -298,7 +322,8 @@ export async function mergeRecordingChunks(
       };
     }
 
-    const merged = Buffer.concat(chunkBuffers);
+    const concatenated = Buffer.concat(chunkBuffers);
+    const merged = await makeWebmSeekable(concatenated);
 
     logger.info("Chunks merged", {
       assessmentId,

--- a/src/lib/media/index.ts
+++ b/src/lib/media/index.ts
@@ -4,3 +4,4 @@ export * from "./screen";
 export * from "./webcam";
 export * from "./video-recorder";
 export * from "./canvas-compositor";
+export * from "./webm-seekable";

--- a/src/lib/media/webm-seekable.ts
+++ b/src/lib/media/webm-seekable.ts
@@ -1,0 +1,101 @@
+/**
+ * MediaRecorder writes WebM streams without a `Duration` element in the Info
+ * section and without a `SeekHead`/`Cues` table. The result is a "non-seekable"
+ * file: the browser shows a duration that grows as it buffers, and the user
+ * can't scrub until the whole file has downloaded.
+ *
+ * Concatenating chunks with `Buffer.concat` preserves that broken metadata.
+ * `makeWebmSeekable` walks the EBML, computes the real duration from cluster
+ * timecodes, and rewrites the metadata block with `Duration` + `SeekHead` +
+ * `Cues` so the browser can seek immediately via HTTP range requests.
+ */
+
+import { Decoder, Reader, tools } from "ts-ebml";
+import { createLogger } from "@/lib/core";
+
+const logger = createLogger("lib:media:webm-seekable");
+
+function bufferToArrayBuffer(buf: Buffer): ArrayBuffer {
+  const ab = new ArrayBuffer(buf.byteLength);
+  new Uint8Array(ab).set(buf);
+  return ab;
+}
+
+function copyToOwnedView(input: Buffer): Uint8Array<ArrayBuffer> {
+  const ab = new ArrayBuffer(input.byteLength);
+  const view = new Uint8Array(ab);
+  view.set(input);
+  return view;
+}
+
+function looksLikeWebm(buf: Buffer): boolean {
+  return (
+    buf.length >= 4 &&
+    buf[0] === 0x1a &&
+    buf[1] === 0x45 &&
+    buf[2] === 0xdf &&
+    buf[3] === 0xa3
+  );
+}
+
+/**
+ * Rewrite a concatenated MediaRecorder WebM so it has proper Duration + Cues
+ * and is seekable in the browser. Returns a `Uint8Array<ArrayBuffer>` (works
+ * directly as a Blob/Supabase upload body); falls back to a copy of the input
+ * buffer (and logs a warning) if the rewrite fails — a non-seekable file is
+ * better than a failed merge.
+ */
+export async function makeWebmSeekable(
+  input: Buffer
+): Promise<Uint8Array<ArrayBuffer>> {
+  if (!looksLikeWebm(input)) {
+    return copyToOwnedView(input);
+  }
+  try {
+    const decoder = new Decoder();
+    const reader = new Reader();
+    reader.logging = false;
+    reader.drop_default_duration = false;
+
+    const ab = bufferToArrayBuffer(input);
+    const elms = decoder.decode(ab);
+    for (const elm of elms) {
+      reader.read(elm);
+    }
+    reader.stop();
+
+    if (!reader.metadatas.length || reader.metadataSize <= 0) {
+      logger.warn("WebM has no parseable metadata; skipping seekability fix", {
+        inputSize: String(input.length),
+      });
+      return copyToOwnedView(input);
+    }
+
+    const refinedMetadata = tools.makeMetadataSeekable(
+      reader.metadatas,
+      reader.duration,
+      reader.cues
+    );
+
+    const body = input.subarray(reader.metadataSize);
+    const outAb = new ArrayBuffer(refinedMetadata.byteLength + body.byteLength);
+    const outView = new Uint8Array(outAb);
+    outView.set(new Uint8Array(refinedMetadata), 0);
+    outView.set(body, refinedMetadata.byteLength);
+
+    logger.info("WebM made seekable", {
+      inputSize: String(input.length),
+      outputSize: String(outView.length),
+      durationTicks: String(reader.duration),
+      cuePoints: String(reader.cues.length),
+    });
+
+    return outView;
+  } catch (err) {
+    logger.warn("Failed to rewrite WebM metadata; returning original buffer", {
+      err: err instanceof Error ? err.message : String(err),
+      inputSize: String(input.length),
+    });
+    return copyToOwnedView(input);
+  }
+}


### PR DESCRIPTION
## Summary

Admin video playback couldn't scrub through screen recordings — duration appeared to grow as the file buffered, and clicking the timeline did nothing until the whole video downloaded.

Root cause: \`MediaRecorder\` writes WebM streams without a \`Duration\` element in the EBML \`Info\` section, and \`Buffer.concat\`-ing chunks server-side produced a final file with no \`SeekHead\` or \`Cues\` table either. Browsers correctly interpreted that as a non-seekable, growing-duration stream.

## Changes

- New helper \`makeWebmSeekable\` in [src/lib/media/webm-seekable.ts](src/lib/media/webm-seekable.ts) using \`ts-ebml\`. Walks the EBML, computes duration from cluster timecodes, and rewrites the metadata block with proper Duration + SeekHead + Cues. Falls back to a copy of the input on any error so a metadata-fix failure can never break the merge.
- Wired into both merge paths: [src/app/api/admin/recording/merge/route.ts](src/app/api/admin/recording/merge/route.ts) (admin on-demand merge) and [src/lib/analysis/video-merge.ts](src/lib/analysis/video-merge.ts) (finalization-time merge).
- Single-chunk fast path now also runs through \`makeWebmSeekable\` and persists the seekable copy to Supabase, so admin playback can scrub immediately even on recordings that didn't need a multi-chunk merge.
- New script [scripts/backfill-recording-seekability.ts](scripts/backfill-recording-seekability.ts) to fix existing \`merged.webm\` files in storage. Supports dry-run by default and a \`--apply\` flag to write changes; can target one assessment or all recordings with \`storageUrl\` set.

## Test plan

- [x] \`npm run check\` (lint + typecheck) — clean
- [x] \`npx vitest run src/lib/analysis/video-merge.test.ts\` — 13/13 pass (test fixtures use minimal byte stubs that aren't valid full WebM, so the helper is mocked at the test boundary)
- [x] Full \`npm test\` — 1900/1904 pass; 4 pre-existing failures on main unrelated to this PR (\`assessment/report/route.test.ts\`, \`recording/session/route.test.ts\`)
- [ ] **Not yet verified end-to-end in a real browser.** Recommended manual check before relying on this in production:
  1. Run \`npx tsx scripts/backfill-recording-seekability.ts <assessmentId> --apply\` against one real assessment
  2. Reload the admin recording tab and confirm the timeline duration is stable on first load and clicking anywhere in the bar seeks immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)