### PR TITLE
fix(tests): patch missing mocks broken by recent main commits

### DIFF
--- a/src/app/api/assessment/report/route.test.ts
+++ b/src/app/api/assessment/report/route.test.ts
@@ -29,6 +29,10 @@ vi.mock("@/server/db", () => ({
       create: (...args: unknown[]) => mockCreateVideoAssessment(...args),
       update: (...args: unknown[]) => mockUpdateVideoAssessment(...args),
     },
+    assessmentApiCall: {
+      create: vi.fn().mockResolvedValue({ id: "test-api-call" }),
+      update: vi.fn().mockResolvedValue({ id: "test-api-call" }),
+    },
   },
 }));
 

--- a/src/app/api/recording/session/route.test.ts
+++ b/src/app/api/recording/session/route.test.ts
@@ -54,6 +54,7 @@ vi.mock("@/server/db", () => ({
 const mockIsE2ETestMode = vi.fn();
 vi.mock("@/lib/core/env", () => ({
   shouldAllowTestModeRecording: () => mockIsE2ETestMode(),
+  isDemoUser: () => false,
   env: {
     DATABASE_URL: "postgresql://localhost:5432/test",
     DIRECT_URL: "postgresql://localhost:5432/test",


### PR DESCRIPTION
## Summary

Two pre-existing test failures on \`main\` (the latest \`main\` CI run is red). Both are stale test mocks, not application bugs. Unblocks https://github.com/skillvee/simulator/pull/408 and any other PR currently red on \`main\` failures.

- **assessment/report/route.test.ts** — \`generateOrFetchReport\` now calls \`generateCandidateNarrative\` → \`logAICall\` → \`db.assessmentApiCall.create\`, but the test only mocked \`db.assessment\` and \`db.videoAssessment\`. Three tests crashed with \`TypeError: Cannot read properties of undefined (reading 'create')\`. Added the missing \`assessmentApiCall\` mock.
- **recording/session/route.test.ts** — \`route.ts\` now imports \`isDemoUser\` from \`@/lib/core/env\` alongside \`shouldAllowTestModeRecording\`, but the env mock only provided \`shouldAllowTestModeRecording\`. The "reject testMode in prod" test crashed before reaching its 403. Added \`isDemoUser: () => false\`, matching the test's intent.

## Test plan

- [x] Both targeted test files now pass: 36/36
- [x] Full \`npm test\` — 1904/1904 pass
- [x] \`npm run check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)