### PR TITLE
fix(recording): capture AI voice in screen recording reliably

### DIFF
--- a/scripts/remerge-recording.ts
+++ b/scripts/remerge-recording.ts
@@ -1,0 +1,119 @@
+import { db } from "@/server/db";
+import { supabaseAdmin, STORAGE_BUCKETS } from "@/lib/external";
+import { makeWebmSeekable } from "@/lib/media/webm-seekable";
+
+const EBML_HEADER = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3]);
+const CLUSTER_ID = new Uint8Array([0x1f, 0x43, 0xb6, 0x75]);
+
+function findFirstClusterOffset(buffer: Uint8Array): number {
+  for (let i = 0; i <= buffer.length - 4; i++) {
+    if (
+      buffer[i] === CLUSTER_ID[0] &&
+      buffer[i + 1] === CLUSTER_ID[1] &&
+      buffer[i + 2] === CLUSTER_ID[2] &&
+      buffer[i + 3] === CLUSTER_ID[3]
+    ) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function hasEbmlHeader(buffer: Uint8Array): boolean {
+  if (buffer.length < 4) return false;
+  return (
+    buffer[0] === EBML_HEADER[0] &&
+    buffer[1] === EBML_HEADER[1] &&
+    buffer[2] === EBML_HEADER[2] &&
+    buffer[3] === EBML_HEADER[3]
+  );
+}
+
+async function remerge(assessmentId: string) {
+  const recordingId = `${assessmentId}-screen`;
+  const recording = await db.recording.findUnique({
+    where: { id: recordingId },
+    include: { segments: { orderBy: { segmentIndex: "asc" } } },
+  });
+  if (!recording) {
+    console.log(`No recording for ${assessmentId}`);
+    return;
+  }
+  const segments = recording.segments.filter((s) => s.chunkPaths.length > 0);
+  if (segments.length === 0) {
+    console.log(`No chunks for ${assessmentId}`);
+    return;
+  }
+
+  const allChunks = segments.flatMap((segment, segIdx) =>
+    segment.chunkPaths.map((path, chunkIdx) => ({
+      path,
+      segIdx,
+      chunkIdx,
+      isFirstSegment: segIdx === 0,
+      isFirstChunkInSegment: chunkIdx === 0,
+    }))
+  );
+
+  const buffers: Buffer[] = [];
+  for (const chunk of allChunks) {
+    const { data, error: dlError } = await supabaseAdmin.storage
+      .from(STORAGE_BUCKETS.RECORDINGS)
+      .download(chunk.path);
+    if (dlError || !data) {
+      console.log(`  skipped ${chunk.path}: ${dlError?.message}`);
+      continue;
+    }
+    let buf = Buffer.from(await data.arrayBuffer());
+    if (!chunk.isFirstSegment && chunk.isFirstChunkInSegment && hasEbmlHeader(buf)) {
+      const off = findFirstClusterOffset(buf);
+      if (off > 0) buf = buf.subarray(off);
+    }
+    buffers.push(buf);
+  }
+
+  if (buffers.length === 0) {
+    console.log(`All downloads failed for ${assessmentId}`);
+    return;
+  }
+
+  const concatenated = Buffer.concat(buffers);
+  const merged = await makeWebmSeekable(concatenated);
+  const mergedPath = `${assessmentId}/merged.webm`;
+
+  const { error: uploadError } = await supabaseAdmin.storage
+    .from(STORAGE_BUCKETS.RECORDINGS)
+    .upload(mergedPath, merged, { contentType: "video/webm", upsert: true });
+  if (uploadError) {
+    console.log(`Upload failed: ${uploadError.message}`);
+    return;
+  }
+
+  const { data: signedData } = await supabaseAdmin.storage
+    .from(STORAGE_BUCKETS.RECORDINGS)
+    .createSignedUrl(mergedPath, 60 * 60 * 24 * 365);
+  if (!signedData?.signedUrl) {
+    console.log(`Failed to create signed URL`);
+    return;
+  }
+
+  await db.recording.update({
+    where: { id: recordingId },
+    data: { storageUrl: signedData.signedUrl },
+  });
+
+  console.log(`Re-merged ${assessmentId}: size=${merged.length}, url updated`);
+}
+
+async function main() {
+  const ids = process.argv.slice(2);
+  if (ids.length === 0) {
+    console.error("Usage: tsx scripts/remerge-recording.ts <assessmentId> [...]");
+    process.exit(1);
+  }
+  for (const id of ids) {
+    await remerge(id);
+  }
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/api/admin/recording/merge/route.ts
+++ b/src/app/api/admin/recording/merge/route.ts
@@ -2,7 +2,7 @@ import { requireAdmin, createLogger } from "@/lib/core";
 import { success, error } from "@/lib/api";
 import { db } from "@/server/db";
 import { supabaseAdmin, STORAGE_BUCKETS } from "@/lib/external";
-import { makeWebmSeekable } from "@/lib/media";
+import { makeWebmSeekable } from "@/lib/media/webm-seekable";
 
 const logger = createLogger("api:admin:recording:merge");
 

--- a/src/lib/analysis/video-merge.ts
+++ b/src/lib/analysis/video-merge.ts
@@ -12,7 +12,7 @@ import { gemini } from "@/lib/ai/gemini";
 import { db } from "@/server/db";
 import { supabaseAdmin, STORAGE_BUCKETS } from "@/lib/external";
 import { createLogger } from "@/lib/core";
-import { makeWebmSeekable } from "@/lib/media";
+import { makeWebmSeekable } from "@/lib/media/webm-seekable";
 
 const logger = createLogger("lib:analysis:video-merge");
 

--- a/src/lib/media/audio-mixer.ts
+++ b/src/lib/media/audio-mixer.ts
@@ -2,14 +2,19 @@
 // into a single MediaStream audio track for recording.
 
 import { createLogger } from "@/lib/core";
+import { getAudioContext } from "./audio";
 
 const logger = createLogger("client:media:audio-mixer");
 
 export interface AudioMixer {
   /** The mixed audio track to add to the recording stream */
   audioTrack: MediaStreamTrack;
-  /** The AudioContext destination node — connect system audio sources here */
-  systemAudioDestination: MediaStreamAudioDestinationNode;
+  /**
+   * Bus node for system audio (e.g. AI voice playback). Connect any
+   * AudioNode here and its output will be summed with the mic into
+   * the recorded audio track.
+   */
+  systemAudioInput: AudioNode;
   /** The AudioContext used by this mixer */
   audioContext: AudioContext;
   /** Stop and clean up all resources */
@@ -24,36 +29,32 @@ export interface AudioMixer {
  * Returns an AudioMixer with a mixed audio track that can be added
  * to the composite MediaStream before recording.
  *
- * The system audio destination node should be used as the output
- * for the AudioStreamer (instead of ctx.destination) so that AI
- * voice responses are captured in the recording.
+ * Connect AI voice (or any other AudioNode you want captured) to
+ * `systemAudioInput`. Both inputs are summed into `audioTrack` via
+ * a single MediaStreamDestination — no MediaStream loopback, which
+ * is unreliable in Chrome's Web Audio implementation.
  */
 export function createAudioMixer(micStream: MediaStream): AudioMixer {
-  const audioContext = new AudioContext();
+  // Reuse the singleton AudioContext that AudioStreamer (AI voice playback)
+  // already lives on. Web Audio forbids connecting nodes across contexts —
+  // a fresh `new AudioContext()` here would cause InvalidAccessError when
+  // the streamer's analyser node is connected into our mixer bus,
+  // silently dropping AI voice from the recording.
+  const audioContext = getAudioContext();
 
-  // Destination node that captures mixed audio as a MediaStream
+  // Single destination node — both mic and system audio sum here, and
+  // its .stream is the recorded audio track.
   const mixedDestination = audioContext.createMediaStreamDestination();
 
-  // Also route to speakers so the candidate hears the AI
-  // (mixedDestination alone would only capture, not play)
-
-  // 1. Microphone input → mixed destination
+  // Mic input → mixer bus
   const micSource = audioContext.createMediaStreamSource(micStream);
   micSource.connect(mixedDestination);
   // Don't connect mic to speakers (would cause feedback)
 
-  // 2. System audio destination — AudioStreamer should connect here
-  //    instead of directly to audioContext.destination
-  const systemAudioDestination = audioContext.createMediaStreamDestination();
-
-  // Route system audio to both the mixer and the speakers
-  const systemSource = audioContext.createMediaStreamSource(
-    systemAudioDestination.stream
-  );
-  systemSource.connect(mixedDestination); // → recording
-  systemSource.connect(audioContext.destination); // → speakers
-
   const audioTrack = mixedDestination.stream.getAudioTracks()[0];
+  if (!audioTrack) {
+    throw new Error("Audio mixer failed to produce an audio track");
+  }
 
   logger.info("Audio mixer created", {
     micTracks: String(micStream.getAudioTracks().length),
@@ -62,13 +63,16 @@ export function createAudioMixer(micStream: MediaStream): AudioMixer {
 
   return {
     audioTrack,
-    systemAudioDestination,
+    systemAudioInput: mixedDestination,
     audioContext,
     stop: () => {
-      micSource.disconnect();
-      systemSource.disconnect();
-      mixedDestination.disconnect();
-      audioContext.close().catch(() => {});
+      try {
+        micSource.disconnect();
+      } catch {
+        // already disconnected
+      }
+      // Do NOT call audioContext.close() — it's the shared singleton used by
+      // AudioStreamer for ongoing AI voice playback elsewhere in the app.
       logger.info("Audio mixer stopped");
     },
   };

--- a/src/lib/media/audio.ts
+++ b/src/lib/media/audio.ts
@@ -127,14 +127,14 @@ export class AudioStreamer {
    * Connect the audio output to an additional destination node.
    * Used by the screen recording mixer to capture AI voice responses.
    */
-  connectToDestination(destination: MediaStreamAudioDestinationNode): void {
+  connectToDestination(destination: AudioNode): void {
     this.analyserNode.connect(destination);
   }
 
   /**
    * Disconnect from an additional destination node.
    */
-  disconnectFromDestination(destination: MediaStreamAudioDestinationNode): void {
+  disconnectFromDestination(destination: AudioNode): void {
     try {
       this.analyserNode.disconnect(destination);
     } catch {
@@ -327,7 +327,7 @@ export function getOutputFrequencyData(): Uint8Array | null {
  * AI voice responses are included in the screen recording.
  */
 export async function connectAudioStreamerToCapture(
-  destination: MediaStreamAudioDestinationNode
+  destination: AudioNode
 ): Promise<void> {
   const streamer = await getAudioStreamer();
   streamer.connectToDestination(destination);
@@ -337,7 +337,7 @@ export async function connectAudioStreamerToCapture(
  * Disconnect the singleton AudioStreamer from a capture destination.
  */
 export async function disconnectAudioStreamerFromCapture(
-  destination: MediaStreamAudioDestinationNode
+  destination: AudioNode
 ): Promise<void> {
   const streamer = await getAudioStreamer();
   streamer.disconnectFromDestination(destination);

--- a/src/lib/media/index.ts
+++ b/src/lib/media/index.ts
@@ -4,4 +4,5 @@ export * from "./screen";
 export * from "./webcam";
 export * from "./video-recorder";
 export * from "./canvas-compositor";
-export * from "./webm-seekable";
+// Note: webm-seekable is server-only (depends on ts-ebml, which breaks in the
+// browser). Import it directly from "@/lib/media/webm-seekable" in server code.

--- a/src/lib/media/webm-seekable.ts
+++ b/src/lib/media/webm-seekable.ts
@@ -10,8 +10,12 @@
  * `Cues` so the browser can seek immediately via HTTP range requests.
  */
 
-import { Decoder, Reader, tools } from "ts-ebml";
 import { createLogger } from "@/lib/core";
+
+// `ts-ebml` is server-only: its CJS modules crash at evaluation time in the
+// browser bundle (`tools.readVint` resolves to undefined). We import it lazily
+// inside `makeWebmSeekable` so the module is never evaluated when this file is
+// pulled into a client bundle via the `@/lib/media` barrel.
 
 const logger = createLogger("lib:media:webm-seekable");
 
@@ -48,10 +52,14 @@ function looksLikeWebm(buf: Buffer): boolean {
 export async function makeWebmSeekable(
   input: Buffer
 ): Promise<Uint8Array<ArrayBuffer>> {
+  if (typeof window !== "undefined") {
+    return copyToOwnedView(input);
+  }
   if (!looksLikeWebm(input)) {
     return copyToOwnedView(input);
   }
   try {
+    const { Decoder, Encoder, Reader, tools } = await import("ts-ebml");
     const decoder = new Decoder();
     const reader = new Reader();
     reader.logging = false;
@@ -71,11 +79,41 @@ export async function makeWebmSeekable(
       return copyToOwnedView(input);
     }
 
-    const refinedMetadata = tools.makeMetadataSeekable(
-      reader.metadatas,
-      reader.duration,
-      reader.cues
-    );
+    // ts-ebml's `Encoder.encode` returns `Buffer.concat(parts).buffer`. For
+    // small results that Buffer comes from Node's shared ~8KB pool, so the
+    // returned ArrayBuffer is the whole pool — not just the encoded bytes —
+    // and using `.byteLength` writes 8192 bytes of mostly-garbage to the file,
+    // stripping the EBML header. Monkey-patch the encoder for the duration of
+    // the (synchronous) `makeMetadataSeekable` call so `encode` returns an
+    // ArrayBuffer of exactly the encoded length.
+    const EncoderProto = (Encoder as unknown as {
+      prototype: {
+        encode: (elms: unknown[]) => ArrayBuffer;
+        encodeChunk: (elm: unknown) => Buffer[];
+      };
+    }).prototype;
+    const originalEncode = EncoderProto.encode;
+    EncoderProto.encode = function (elms: unknown[]) {
+      const parts: Buffer[] = elms.reduce<Buffer[]>(
+        (lst, elm) => lst.concat(this.encodeChunk(elm)),
+        []
+      );
+      const concatenated = Buffer.concat(parts);
+      const out = new ArrayBuffer(concatenated.byteLength);
+      new Uint8Array(out).set(concatenated);
+      return out;
+    };
+
+    let refinedMetadata: ArrayBuffer;
+    try {
+      refinedMetadata = tools.makeMetadataSeekable(
+        reader.metadatas,
+        reader.duration,
+        reader.cues
+      );
+    } finally {
+      EncoderProto.encode = originalEncode;
+    }
 
     const body = input.subarray(reader.metadataSize);
     const outAb = new ArrayBuffer(refinedMetadata.byteLength + body.byteLength);


### PR DESCRIPTION
## Summary
- Reuse the singleton `AudioContext` in the screen-recording mixer so the AI voice analyser can actually be wired into the mixed track. Previously a fresh `new AudioContext()` caused `InvalidAccessError` when connecting cross-context nodes, silently dropping AI voice from the recording.
- Make `webm-seekable` lazy-import `ts-ebml` and drop it from the `@/lib/media` barrel — `ts-ebml` is server-only and crashed at module evaluation time when pulled into client bundles.
- Patch `ts-ebml`'s `Encoder.encode` to return an exact-length `ArrayBuffer` before `makeMetadataSeekable`. The library was returning the entire shared Node Buffer pool (~8KB) for small encodes, which corrupted merged WebMs by writing 8KB of garbage in place of the EBML header.
- Add `scripts/remerge-recording.ts` to repair recordings already saved with the corruption.

## Test plan
- [ ] Run a fresh assessment, hold a coworker call, then verify the merged recording in admin playback contains both mic and AI voice.
- [ ] Spot-check that an existing pre-fix recording can be repaired via `npx tsx scripts/remerge-recording.ts <assessmentId>` and plays cleanly.
- [ ] `npm run check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)