### PR TITLE
feat(marketing): redesign product page, add brochure, refresh hero copy

### DIFF
--- a/brochure.md
+++ b/brochure.md
@@ -1,0 +1,75 @@
+# Skillvee — for Hiring Managers
+
+**Watch them work. Then hire.**
+
+*A 45-minute work simulation that shows you — before you ever schedule an onsite — how a candidate communicates, collaborates, and ships real output.*
+
+---
+
+## The pain you're living with
+
+**You can't tell candidates apart anymore.** Applications per role have gone from dozens to hundreds. 74% of resumes are AI-written and they all read the same. The top of your funnel is noise.
+
+**Interviews stopped being reliable.** 45% of candidates use AI mid-interview — you're evaluating their copilot, not them. Rounds are up 42% since 2021. Your team burns 38+ engineering hours per hire across 4–5 rounds, and mis-hires still slip through.
+
+**Your current tools don't answer the question that matters.** HackerRank tests algorithm trivia nobody uses at work, and bans AI — pretending it doesn't exist. Take-homes come back as polished AI-generated repos you can't verify. Neither tells you: *can this person actually do the job?*
+
+**A bad hire costs more than a slow one.** $100K+ in salary, ramp, team drag, and replacement — plus the opportunity cost of the teammate you didn't hire instead.
+
+---
+
+## How Skillvee can help
+
+**Watch a candidate do Day 1 of the job before you hire them.**
+
+Every candidate completes a 45-minute work simulation. They get an assigment from an AI manager explaining the task. They ask clarifying questions, collaborate with teammates, use the AI tools they'd use on the job, submit their work and defend their decisions in a final debrief. Screen recorded end-to-end.
+
+You get back:
+- **A standardized scorecard** — communication, problem-solving, AI leverage, quality of output, collaboration
+- **The full recording + transcripts** — skim a 45-min session in 5 minutes
+- **Side-by-side comparison** — same task, same rubric, across every candidate
+
+---
+
+## Why hiring managers get excited
+
+- **Get your team's hours back.** Screen out 80% of weak candidates *before* anyone on your team takes an interview. Only onsite the candidates you've already seen do the work.
+- **Better hires, fewer surprises.** Evidence of real work beats a 45-minute panel impression every time.
+- **Standardized signal.** Same scenario, same rubric — apples to apples. Reduces the "the engineer who liked them most" problem.
+- **A process candidates respect.** Realistic work beats trivia. Modern engineers would rather do 45 minutes of the real job than a LeetCode gauntlet — and your offer acceptance reflects it.
+- **Shorter time-to-hire.** Front-load real-work signal; stop losing top candidates to 6-week processes.
+
+---
+
+## Frequently asked questions
+
+**"Will candidates actually complete a 45-minute simulation?"**
+It's async and on their schedule. Completion rates beat take-homes because it's engaging, realistic, and — unlike a take-home — finite. Candidates know exactly what they're signing up for.
+
+**"Is this fair? What about bias?"**
+Every candidate does the same scenario, scored against the same rubric. That's *more* structured than a typical panel interview, not less. Job-relevant, consistent, and auditable.
+
+**"What if candidates just use AI to do everything?"**
+Good — so do your employees. We measure *how* they use AI, not whether. Prompting skill, judgment on outputs, and knowing when to override the model are the exact signals you want for 2026 hiring.
+
+**"How does this fit our ATS and existing process?"**
+Drop-in: send candidates a link, export results to your ATS — we integrate with any ATS (Greenhouse, Lever, Ashby, Workday, and the rest). No rip-and-replace. Most teams run Skillvee as a pre-onsite screen, replacing a take-home or tech screen.
+
+**"Data privacy and candidate consent?"**
+Explicit consent flow before recording. Configurable retention. Candidates see what's captured and why.
+
+**"How is this different from HackerRank / CodeSignal / Codility?"**
+They test algorithm puzzles in sandboxed IDEs and ban AI. We simulate the actual job — requirements gathering, stakeholder conversations, AI-assisted work, final defense. Different question, different answer.
+
+---
+
+## See it for yourself
+
+The fastest way to understand Skillvee is to watch a real candidate session and walk through the scorecard together.
+
+**Book a 20-minute demo:** [german@skillvee.com](mailto:german@skillvee.com)
+
+We'll show you:
+- A real candidate replay end-to-end
+- The scorecard and rubric
+- How teams like yours are using it in their current pipeline

--- a/src/app/[locale]/brochure/page.tsx
+++ b/src/app/[locale]/brochure/page.tsx
@@ -1,0 +1,1081 @@
+"use client";
+
+import Image from "next/image";
+import { useLocale } from "next-intl";
+import {
+  MessageSquare,
+  FileCode,
+  Video,
+  Sparkles,
+  Globe,
+  Mail,
+  Code2,
+  Users,
+  BarChart3,
+  TrendingUp,
+  DollarSign,
+  HeartHandshake,
+  FileText,
+  Mic,
+  Clock,
+  Target,
+  Zap,
+  ArrowRight,
+} from "lucide-react";
+
+const content = {
+  en: {
+    tagline: "Work simulations that show who can actually do the job",
+    hero: {
+      heading: "Watch them work. Then hire.",
+      subtitle:
+        "See exactly how candidates communicate, collaborate, and solve problems—before you make the offer. No more expensive hiring mistakes.",
+    },
+    pain: {
+      label: "The problem",
+      headline: "AI broke hiring — and your process hasn't caught up.",
+      lede:
+        "The filters you've used for 20 years all stopped working at the same time. None of this was a problem 12 months ago.",
+      items: [
+        {
+          strong: "Resumes stopped telling you anything.",
+          rest:
+            "Every resume is AI-polished now — they all read the same. You can't tell who's actually qualified.",
+        },
+        {
+          strong: "Interviews stopped measuring the candidate.",
+          rest:
+            "45% of candidates are running AI in a second window. You're grading their copilot, not them.",
+        },
+        {
+          strong: "Take-homes stopped being proof of work.",
+          rest:
+            "You can't tell what the candidate wrote and what their AI wrote. Neither can anyone else.",
+        },
+      ],
+    },
+    solution: {
+      label: "How Skillvee can help",
+      title: "Watch a candidate do Day 1 of the job — before you hire them.",
+      description:
+        "Every candidate completes a 45-minute work simulation. They get an assignment from an AI manager explaining the task. They ask clarifying questions, collaborate with teammates, use the AI tools they'd use on the job, submit their work and defend their decisions in a final debrief. Screen recorded end-to-end.",
+      items: [
+        {
+          title: "Standardized scorecard",
+          desc:
+            "Communication, problem-solving, AI leverage, quality of output, collaboration.",
+        },
+        {
+          title: "Full recording + transcripts",
+          desc:
+            "Skim a 45-minute session in 5 minutes. Jump to the moments that matter.",
+        },
+        {
+          title: "Side-by-side comparison",
+          desc: "Same task, same rubric, across every candidate in your pipeline.",
+        },
+      ],
+    },
+    roles: {
+      label: "Works for every role you hire",
+      intro: "Custom simulations tailored to the specific job you're hiring for.",
+      items: {
+        eng: {
+          title: "Software Engineers",
+          desc: "Build features, review code, collaborate with stakeholders.",
+        },
+        pm: {
+          title: "Product Managers",
+          desc: "Prioritize backlogs, run meetings, present roadmaps.",
+        },
+        ds: {
+          title: "Data Scientists",
+          desc: "Analyze data, communicate findings, make recommendations.",
+        },
+        program: {
+          title: "Program Managers",
+          desc: "Coordinate teams, resolve conflicts, drive alignment.",
+        },
+        sales: {
+          title: "Sales",
+          desc: "Run discovery calls, handle objections, close deals.",
+        },
+        cs: {
+          title: "Customer Success",
+          desc: "Onboard clients, handle escalations, drive renewals.",
+        },
+      },
+    },
+    benefits: {
+      label: "Why hiring managers get excited",
+      items: [
+        {
+          hook: "Skip 80% of weak candidates.",
+          title: "Get your team's hours back",
+          desc:
+            "Screen candidates before anyone on your team meets them. Senior managers stop burning a day a week on interview loops.",
+        },
+        {
+          hook: "Evidence, not gut feel.",
+          title: "Better hires, fewer surprises",
+          desc:
+            "You've already seen them gather requirements, solve problems, and ship. The 'great interview, bad hire' pattern stops happening.",
+        },
+        {
+          hook: "Days, not weeks.",
+          title: "Shorter time-to-hire",
+          desc:
+            "Front-load real-work signal and cut interview rounds in half. Stop losing top candidates to 6-week processes.",
+        },
+      ],
+    },
+    faq: {
+      label: "Frequently asked questions",
+      items: [
+        {
+          q: "What if candidates just use AI to do everything?",
+          a:
+            "Good — so do your employees. We measure how they use AI, not whether. Prompting skill, judgment on outputs, and knowing when to override the model are the exact signals you want for 2026 hiring.",
+        },
+        {
+          q: "How is this different from HackerRank / CodeSignal / Codility?",
+          a:
+            "They test algorithm puzzles in sandboxed IDEs and ban AI. We simulate the actual job — requirements gathering, stakeholder conversations, AI-assisted work, final defense. Different question, different answer.",
+        },
+        {
+          q: "Will candidates actually complete a 45-minute simulation?",
+          a:
+            "It's async and on their schedule. Completion rates beat take-homes because it's engaging, realistic, and — unlike a take-home — finite. Candidates know exactly what they're signing up for.",
+        },
+      ],
+      seeAll: "See complete FAQ",
+    },
+    cta: {
+      label: "See it for yourself",
+      heading:
+        "Watch a real candidate session and walk through the scorecard with us.",
+      description:
+        "20 minutes. We'll show you a real candidate replay end-to-end, the scorecard and rubric, and how teams like yours are using it in their current pipeline.",
+      button: "Book a 20-min demo",
+      mailSubject: "Skillvee demo request",
+    },
+    footer: {
+      left: "Skillvee · german@skillvee.com · www.skillvee.com",
+      right: "Hiring for engineering, data, or product roles",
+    },
+  },
+  es: {
+    tagline:
+      "Simulaciones de trabajo que muestran quién realmente puede hacer el trabajo",
+    hero: {
+      heading: "Míralos trabajar. Después contrata.",
+      subtitle:
+        "Ve exactamente cómo los candidatos se comunican, colaboran y resuelven problemas—antes de hacer la oferta. Se acabaron los errores costosos de contratación.",
+    },
+    pain: {
+      label: "El problema",
+      headline: "La IA rompió la contratación — y tu proceso no se ha adaptado.",
+      lede:
+        "Los filtros que has usado durante 20 años dejaron de funcionar al mismo tiempo. Nada de esto era un problema hace 12 meses.",
+      items: [
+        {
+          strong: "Los currículums dejaron de decirte algo.",
+          rest:
+            "Todos los currículums están pulidos por IA — todos se leen igual. No puedes saber quién está realmente calificado.",
+        },
+        {
+          strong: "Las entrevistas dejaron de medir al candidato.",
+          rest:
+            "El 45% de los candidatos usa IA en otra ventana. Estás evaluando a su copiloto, no a ellos.",
+        },
+        {
+          strong: "Los take-homes dejaron de ser prueba de trabajo.",
+          rest:
+            "No puedes distinguir qué escribió el candidato y qué escribió su IA. Nadie puede.",
+        },
+      ],
+    },
+    solution: {
+      label: "Cómo puede ayudarte Skillvee",
+      title: "Ve al candidato hacer el Día 1 del trabajo — antes de contratarlo.",
+      description:
+        "Cada candidato completa una simulación de trabajo de 45 minutos. Recibe una tarea de un manager con IA. Hace preguntas de clarificación, colabora con el equipo, usa las herramientas de IA que usaría en el trabajo, entrega su trabajo y defiende sus decisiones en un debrief final. Grabación de pantalla de principio a fin.",
+      items: [
+        {
+          title: "Scorecard estandarizado",
+          desc:
+            "Comunicación, resolución de problemas, uso de IA, calidad del output, colaboración.",
+        },
+        {
+          title: "Grabación completa + transcripciones",
+          desc:
+            "Revisa una sesión de 45 minutos en 5. Salta a los momentos que importan.",
+        },
+        {
+          title: "Comparación lado a lado",
+          desc:
+            "Misma tarea, mismo rubro, entre todos los candidatos de tu pipeline.",
+        },
+      ],
+    },
+    roles: {
+      label: "Funciona para cada rol que contrates",
+      intro:
+        "Simulaciones personalizadas al trabajo específico que estás contratando.",
+      items: {
+        eng: {
+          title: "Ingenieros de Software",
+          desc: "Construir features, revisar código, colaborar con stakeholders.",
+        },
+        pm: {
+          title: "Product Managers",
+          desc: "Priorizar backlogs, dirigir reuniones, presentar roadmaps.",
+        },
+        ds: {
+          title: "Data Scientists",
+          desc: "Analizar datos, comunicar hallazgos, dar recomendaciones.",
+        },
+        program: {
+          title: "Program Managers",
+          desc: "Coordinar equipos, resolver conflictos, lograr alineación.",
+        },
+        sales: {
+          title: "Ventas",
+          desc: "Hacer discovery calls, manejar objeciones, cerrar negocios.",
+        },
+        cs: {
+          title: "Customer Success",
+          desc: "Onboardear clientes, manejar escalaciones, impulsar renovaciones.",
+        },
+      },
+    },
+    benefits: {
+      label: "Por qué los hiring managers se emocionan",
+      items: [
+        {
+          hook: "Salta el 80% de candidatos débiles.",
+          title: "Recupera las horas de tu equipo",
+          desc:
+            "Filtra candidatos antes de que alguien de tu equipo los conozca. Los managers senior dejan de quemar un día a la semana en loops de entrevistas.",
+        },
+        {
+          hook: "Evidencia, no intuición.",
+          title: "Mejores contrataciones, menos sorpresas",
+          desc:
+            "Ya los has visto recopilar requisitos, resolver problemas y entregar. El patrón de 'gran entrevista, mala contratación' deja de pasar.",
+        },
+        {
+          hook: "Días, no semanas.",
+          title: "Menor tiempo de contratación",
+          desc:
+            "Adelanta la señal de trabajo real y corta las rondas de entrevistas a la mitad. Deja de perder a los mejores candidatos en procesos de 6 semanas.",
+        },
+      ],
+    },
+    faq: {
+      label: "Preguntas frecuentes",
+      items: [
+        {
+          q: "¿Qué pasa si los candidatos usan IA para hacer todo?",
+          a:
+            "Bien — igual que tus empleados. Medimos cómo usan la IA, no si la usan. Habilidad de prompting, juicio sobre outputs, y saber cuándo sobreescribir al modelo son exactamente las señales que quieres para contratar en 2026.",
+        },
+        {
+          q: "¿En qué se diferencia de HackerRank / CodeSignal / Codility?",
+          a:
+            "Ellos prueban puzzles de algoritmos en IDEs aislados y prohíben la IA. Nosotros simulamos el trabajo real — recopilación de requisitos, conversaciones con stakeholders, trabajo asistido por IA, defensa final. Pregunta distinta, respuesta distinta.",
+        },
+        {
+          q: "¿Los candidatos realmente van a completar una simulación de 45 minutos?",
+          a:
+            "Es asíncrona y en su propio horario. La tasa de completitud supera a los take-homes porque es atractiva, realista y — a diferencia de un take-home — finita. Los candidatos saben exactamente en qué se están metiendo.",
+        },
+      ],
+      seeAll: "Ver FAQ completo",
+    },
+    cta: {
+      label: "Velo por ti mismo",
+      heading:
+        "Mira una sesión real con un candidato y repasemos el scorecard juntos.",
+      description:
+        "20 minutos. Te mostraremos el replay real de un candidato de principio a fin, el scorecard y el rubro, y cómo equipos como el tuyo lo están usando en su pipeline actual.",
+      button: "Reserva un demo de 20 min",
+      mailSubject: "Solicitud de demo de Skillvee",
+    },
+    footer: {
+      left: "Skillvee · german@skillvee.com · www.skillvee.com",
+      right: "Contratando para roles de ingeniería, data o producto",
+    },
+  },
+} as const;
+
+type Locale = keyof typeof content;
+
+export default function HiringManagerBrochurePage() {
+  const locale = useLocale();
+  const c = content[locale as Locale] ?? content.en;
+  const painIcons = [FileText, Mic, Code2];
+
+  return (
+    <div className="min-h-screen bg-white text-slate-900">
+      <div
+        className="br-container"
+        style={{ maxWidth: 960, margin: "0 auto", padding: "48px 32px" }}
+      >
+        {/* ── HEADER ── */}
+        <header
+          className="br-header"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingBottom: 24,
+            marginBottom: 40,
+            borderBottom: "3px solid #237CF1",
+            gap: 16,
+          }}
+        >
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: 6, minWidth: 0 }}
+          >
+            <Image
+              src="/skillvee-logo.png"
+              alt="SkillVee"
+              width={747}
+              height={226}
+              style={{ width: 180, height: "auto", maxWidth: "100%" }}
+            />
+            <p
+              className="br-tagline"
+              style={{
+                fontSize: 16,
+                color: "#475569",
+                fontWeight: 600,
+                margin: 0,
+              }}
+            >
+              {c.tagline}
+            </p>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              fontSize: 12,
+              color: "#94a3b8",
+              flexShrink: 0,
+            }}
+          >
+            <Globe size={14} />
+            <span>www.skillvee.com</span>
+          </div>
+        </header>
+
+        {/* ── HERO ── */}
+        <div style={{ marginBottom: 48 }}>
+          <h1
+            className="br-hero"
+            style={{
+              fontSize: 40,
+              fontWeight: 900,
+              color: "#0f172a",
+              margin: "0 0 16px",
+              lineHeight: 1.15,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {c.hero.heading}
+          </h1>
+          <p
+            style={{
+              fontSize: 15,
+              color: "#475569",
+              margin: 0,
+              lineHeight: 1.6,
+              maxWidth: 720,
+            }}
+          >
+            {c.hero.subtitle}
+          </p>
+        </div>
+
+        {/* ── THE PAIN ── */}
+        <div style={{ marginBottom: 56 }}>
+          <SectionLabel>{c.pain.label}</SectionLabel>
+          <h2
+            className="br-pain-headline"
+            style={{
+              fontSize: 36,
+              fontWeight: 900,
+              color: "#0f172a",
+              margin: "0 0 14px",
+              lineHeight: 1.15,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {c.pain.headline}
+          </h2>
+          <p
+            className="br-pain-lede"
+            style={{
+              fontSize: 15,
+              color: "#475569",
+              margin: "0 0 8px",
+              lineHeight: 1.6,
+            }}
+          >
+            {c.pain.lede}
+          </p>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 0,
+              marginTop: 16,
+            }}
+          >
+            {c.pain.items.map((item, i) => {
+              const Icon = painIcons[i];
+              return (
+                <PainLine key={i} icon={<Icon size={18} color="#ef4444" />}>
+                  <strong style={{ fontWeight: 800 }}>{item.strong}</strong>{" "}
+                  <span style={{ fontWeight: 400, color: "#475569" }}>
+                    {item.rest}
+                  </span>
+                </PainLine>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* ── SOLUTION ── */}
+        <div
+          className="br-panel"
+          style={{
+            background: "rgba(35, 124, 241, 0.04)",
+            border: "1px solid rgba(35, 124, 241, 0.2)",
+            borderRadius: 12,
+            padding: "28px 32px",
+            marginBottom: 40,
+          }}
+        >
+          <SectionLabel>{c.solution.label}</SectionLabel>
+          <h3
+            className="br-headline"
+            style={{
+              fontSize: 22,
+              fontWeight: 900,
+              color: "#0f172a",
+              margin: "0 0 12px",
+            }}
+          >
+            {c.solution.title}
+          </h3>
+          <p style={{ fontSize: 14, color: "#475569", margin: "0 0 20px", lineHeight: 1.6 }}>
+            {c.solution.description}
+          </p>
+          <div
+            className="br-grid-3"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr 1fr",
+              gap: 16,
+            }}
+          >
+            <SolutionItem
+              icon={<FileCode size={16} color="#237CF1" />}
+              title={c.solution.items[0].title}
+              desc={c.solution.items[0].desc}
+            />
+            <SolutionItem
+              icon={<Video size={16} color="#237CF1" />}
+              title={c.solution.items[1].title}
+              desc={c.solution.items[1].desc}
+            />
+            <SolutionItem
+              icon={<MessageSquare size={16} color="#237CF1" />}
+              title={c.solution.items[2].title}
+              desc={c.solution.items[2].desc}
+            />
+          </div>
+        </div>
+
+        {/* ── ROLES ── */}
+        <div style={{ marginBottom: 48 }}>
+          <SectionLabel>{c.roles.label}</SectionLabel>
+          <p
+            style={{
+              fontSize: 14,
+              color: "#475569",
+              margin: "0 0 20px",
+              lineHeight: 1.6,
+            }}
+          >
+            {c.roles.intro}
+          </p>
+          <div
+            className="br-roles-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr 1fr",
+              gap: 14,
+            }}
+          >
+            <RoleCard
+              icon={<Code2 size={18} color="#237CF1" />}
+              iconBg="rgba(35, 124, 241, 0.12)"
+              title={c.roles.items.eng.title}
+              desc={c.roles.items.eng.desc}
+            />
+            <RoleCard
+              icon={<Users size={18} color="#a855f7" />}
+              iconBg="rgba(168, 85, 247, 0.12)"
+              title={c.roles.items.pm.title}
+              desc={c.roles.items.pm.desc}
+            />
+            <RoleCard
+              icon={<BarChart3 size={18} color="#22c55e" />}
+              iconBg="rgba(34, 197, 94, 0.12)"
+              title={c.roles.items.ds.title}
+              desc={c.roles.items.ds.desc}
+            />
+            <RoleCard
+              icon={<TrendingUp size={18} color="#f59e0b" />}
+              iconBg="rgba(245, 158, 11, 0.15)"
+              title={c.roles.items.program.title}
+              desc={c.roles.items.program.desc}
+            />
+            <RoleCard
+              icon={<DollarSign size={18} color="#f43f5e" />}
+              iconBg="rgba(244, 63, 94, 0.12)"
+              title={c.roles.items.sales.title}
+              desc={c.roles.items.sales.desc}
+            />
+            <RoleCard
+              icon={<HeartHandshake size={18} color="#06b6d4" />}
+              iconBg="rgba(6, 182, 212, 0.12)"
+              title={c.roles.items.cs.title}
+              desc={c.roles.items.cs.desc}
+            />
+          </div>
+        </div>
+
+        {/* ── WHY EXCITED ── */}
+        <div style={{ marginBottom: 48 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              marginBottom: 20,
+            }}
+          >
+            <Sparkles size={18} color="#237CF1" />
+            <SectionLabel style={{ marginBottom: 0 }}>
+              {c.benefits.label}
+            </SectionLabel>
+          </div>
+          <div
+            className="br-benefits-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr 1fr",
+              gap: 16,
+            }}
+          >
+            <BenefitHero
+              icon={<Clock size={22} color="#237CF1" />}
+              hook={c.benefits.items[0].hook}
+              title={c.benefits.items[0].title}
+              desc={c.benefits.items[0].desc}
+            />
+            <BenefitHero
+              icon={<Target size={22} color="#237CF1" />}
+              hook={c.benefits.items[1].hook}
+              title={c.benefits.items[1].title}
+              desc={c.benefits.items[1].desc}
+            />
+            <BenefitHero
+              icon={<Zap size={22} color="#237CF1" />}
+              hook={c.benefits.items[2].hook}
+              title={c.benefits.items[2].title}
+              desc={c.benefits.items[2].desc}
+            />
+          </div>
+        </div>
+
+        {/* ── FAQ ── */}
+        <div style={{ marginBottom: 40 }}>
+          <SectionLabel>{c.faq.label}</SectionLabel>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 14,
+              marginTop: 16,
+            }}
+          >
+            {c.faq.items.map((item, i) => (
+              <FAQItem key={i} q={item.q} a={item.a} />
+            ))}
+          </div>
+          <a
+            href={`/${locale}/faq`}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              marginTop: 18,
+              marginLeft: 19,
+              fontSize: 13,
+              fontWeight: 700,
+              color: "#237CF1",
+              textDecoration: "none",
+            }}
+          >
+            {c.faq.seeAll}
+            <ArrowRight size={14} />
+          </a>
+        </div>
+
+        {/* ── CTA ── */}
+        <div
+          className="br-cta"
+          style={{
+            background: "linear-gradient(135deg, #237CF1 0%, #1e6fd9 100%)",
+            borderRadius: 16,
+            padding: "36px 40px",
+            color: "#ffffff",
+            marginBottom: 32,
+          }}
+        >
+          <p
+            style={{
+              fontSize: 13,
+              fontWeight: 900,
+              textTransform: "uppercase",
+              letterSpacing: "0.2em",
+              color: "rgba(255,255,255,0.8)",
+              margin: "0 0 10px",
+            }}
+          >
+            {c.cta.label}
+          </p>
+          <h3
+            className="br-cta-headline"
+            style={{
+              fontSize: 24,
+              fontWeight: 900,
+              color: "#ffffff",
+              margin: "0 0 10px",
+              lineHeight: 1.3,
+            }}
+          >
+            {c.cta.heading}
+          </h3>
+          <p
+            style={{
+              fontSize: 14,
+              color: "rgba(255,255,255,0.9)",
+              margin: "0 0 20px",
+              lineHeight: 1.6,
+            }}
+          >
+            {c.cta.description}
+          </p>
+          <a
+            href={`mailto:german@skillvee.com?subject=${encodeURIComponent(c.cta.mailSubject)}`}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+              background: "#ffffff",
+              color: "#237CF1",
+              fontSize: 15,
+              fontWeight: 700,
+              padding: "12px 22px",
+              borderRadius: 10,
+              textDecoration: "none",
+            }}
+          >
+            <Mail size={16} />
+            {c.cta.button}
+          </a>
+        </div>
+
+        {/* ── FOOTER ── */}
+        <footer
+          className="br-footer"
+          style={{
+            borderTop: "3px solid #237CF1",
+            paddingTop: 20,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 16,
+            flexWrap: "wrap",
+          }}
+        >
+          <p
+            style={{
+              fontSize: 13,
+              color: "#64748b",
+              margin: 0,
+            }}
+          >
+            {c.footer.left}
+          </p>
+          <p
+            style={{
+              fontSize: 12,
+              color: "#94a3b8",
+              margin: 0,
+            }}
+          >
+            {c.footer.right}
+          </p>
+        </footer>
+      </div>
+
+      {/* ── Mobile responsive overrides ── */}
+      <style jsx>{`
+        @media (max-width: 640px) {
+          .br-container {
+            padding: 24px 16px !important;
+          }
+          .br-container > * {
+            margin-bottom: 32px !important;
+          }
+          .br-container > footer {
+            margin-bottom: 0 !important;
+          }
+          .br-header {
+            flex-direction: column;
+            align-items: flex-start !important;
+            gap: 10px !important;
+          }
+          .br-tagline {
+            font-size: 13px !important;
+            font-weight: 500 !important;
+          }
+          .br-hero {
+            font-size: 24px !important;
+          }
+          .br-pain-headline {
+            font-size: 24px !important;
+          }
+          .br-grid-2 {
+            grid-template-columns: 1fr !important;
+            gap: 12px !important;
+          }
+          .br-roles-grid {
+            grid-template-columns: 1fr !important;
+            gap: 10px !important;
+          }
+          .br-benefits-grid {
+            grid-template-columns: 1fr !important;
+            gap: 12px !important;
+          }
+          .br-grid-3 {
+            grid-template-columns: 1fr !important;
+            gap: 14px !important;
+          }
+          .br-headline {
+            font-size: 18px !important;
+          }
+          .br-panel {
+            padding: 22px 20px !important;
+          }
+          .br-cta {
+            padding: 28px 22px !important;
+          }
+          .br-cta-headline {
+            font-size: 20px !important;
+          }
+          .br-footer {
+            flex-direction: column;
+            align-items: flex-start !important;
+            gap: 6px !important;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+/* ── Helper components ── */
+
+function SectionLabel({
+  children,
+  style,
+}: {
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <h2
+      style={{
+        fontSize: 13,
+        fontWeight: 900,
+        textTransform: "uppercase",
+        letterSpacing: "0.2em",
+        color: "#237CF1",
+        marginBottom: 16,
+        marginTop: 0,
+        ...style,
+      }}
+    >
+      {children}
+    </h2>
+  );
+}
+
+function RoleCard({
+  icon,
+  iconBg,
+  title,
+  desc,
+}: {
+  icon: React.ReactNode;
+  iconBg: string;
+  title: string;
+  desc: string;
+}) {
+  return (
+    <div
+      style={{
+        background: "#f8fafc",
+        borderRadius: 12,
+        padding: "16px 18px",
+        display: "flex",
+        alignItems: "flex-start",
+        gap: 12,
+      }}
+    >
+      <div
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: 8,
+          background: iconBg,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        {icon}
+      </div>
+      <div style={{ minWidth: 0 }}>
+        <p
+          style={{
+            fontSize: 14,
+            fontWeight: 700,
+            color: "#0f172a",
+            margin: "0 0 4px",
+          }}
+        >
+          {title}
+        </p>
+        <p
+          style={{
+            fontSize: 12.5,
+            color: "#64748b",
+            margin: 0,
+            lineHeight: 1.5,
+          }}
+        >
+          {desc}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function PainLine({
+  icon,
+  children,
+}: {
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        gap: 14,
+        padding: "16px 0",
+        borderBottom: "1px solid #e2e8f0",
+      }}
+    >
+      {icon ? (
+        <div
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 10,
+            background: "rgba(239, 68, 68, 0.1)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+            marginTop: 2,
+          }}
+        >
+          {icon}
+        </div>
+      ) : null}
+      <p
+        style={{
+          fontSize: 16,
+          fontWeight: 500,
+          color: "#0f172a",
+          margin: 0,
+          lineHeight: 1.55,
+          flex: 1,
+        }}
+      >
+        {children}
+      </p>
+    </div>
+  );
+}
+
+function SolutionItem({
+  icon,
+  title,
+  desc,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  desc: string;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+      <div
+        style={{
+          width: 30,
+          height: 30,
+          borderRadius: 8,
+          background: "rgba(35, 124, 241, 0.1)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+          marginTop: 2,
+        }}
+      >
+        {icon}
+      </div>
+      <div>
+        <p style={{ fontSize: 13, fontWeight: 700, color: "#0f172a", margin: 0 }}>
+          {title}
+        </p>
+        <p
+          style={{
+            fontSize: 12.5,
+            color: "#64748b",
+            margin: "2px 0 0",
+            lineHeight: 1.5,
+          }}
+        >
+          {desc}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function BenefitHero({
+  icon,
+  hook,
+  title,
+  desc,
+}: {
+  icon: React.ReactNode;
+  hook: string;
+  title: string;
+  desc: string;
+}) {
+  return (
+    <div
+      style={{
+        background:
+          "linear-gradient(160deg, rgba(35, 124, 241, 0.07) 0%, rgba(35, 124, 241, 0.02) 100%)",
+        border: "1px solid rgba(35, 124, 241, 0.2)",
+        borderRadius: 14,
+        padding: "22px 22px 20px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+      }}
+    >
+      <div
+        style={{
+          width: 44,
+          height: 44,
+          borderRadius: 11,
+          background: "rgba(35, 124, 241, 0.12)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        {icon}
+      </div>
+      <p
+        style={{
+          fontSize: 18,
+          fontWeight: 800,
+          color: "#237CF1",
+          margin: 0,
+          lineHeight: 1.25,
+          letterSpacing: "-0.01em",
+        }}
+      >
+        {hook}
+      </p>
+      <p
+        style={{
+          fontSize: 15,
+          fontWeight: 700,
+          color: "#0f172a",
+          margin: 0,
+          lineHeight: 1.3,
+        }}
+      >
+        {title}
+      </p>
+      <p
+        style={{
+          fontSize: 13,
+          color: "#475569",
+          margin: 0,
+          lineHeight: 1.55,
+        }}
+      >
+        {desc}
+      </p>
+    </div>
+  );
+}
+
+function FAQItem({ q, a }: { q: string; a: string }) {
+  return (
+    <div
+      style={{
+        borderLeft: "3px solid rgba(35, 124, 241, 0.4)",
+        paddingLeft: 16,
+      }}
+    >
+      <p style={{ fontSize: 14, fontWeight: 700, color: "#0f172a", margin: "0 0 4px" }}>
+        {q}
+      </p>
+      <p style={{ fontSize: 13, color: "#475569", margin: 0, lineHeight: 1.6 }}>
+        {a}
+      </p>
+    </div>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -133,8 +133,8 @@ export default function HomePage() {
         />
 
         {/* Main Content - Grid Layout */}
-        <div className="relative z-10 max-w-[1400px] mx-auto px-6 w-full">
-          <div className="grid lg:grid-cols-[1fr,1.2fr] gap-12 lg:gap-12 items-center">
+        <div className="relative z-10 max-w-[1400px] mx-auto px-6 sm:px-10 lg:px-16 xl:px-20 w-full">
+          <div className="grid lg:grid-cols-[1fr,1.2fr] gap-12 lg:gap-16 items-center">
             {/* Left side - Text content */}
             <motion.div
               initial={{ opacity: 0, y: 30 }}
@@ -142,11 +142,6 @@ export default function HomePage() {
               transition={{ duration: 0.8 }}
               className="text-center lg:text-left"
             >
-              <div className="inline-flex items-center gap-2 bg-white/5 border border-white/10 rounded-full px-4 py-2 mb-6">
-                <span className="w-2 h-2 bg-emerald-400 rounded-full animate-pulse" />
-                <span className="text-slate-400 text-sm">{t("hero.badge")}</span>
-              </div>
-
               <h1 className="text-4xl sm:text-5xl lg:text-6xl xl:text-7xl font-black text-white leading-[1.05] mb-6">
                 {t("hero.title")}
                 <br />

--- a/src/app/[locale]/presentation-v2/page.tsx
+++ b/src/app/[locale]/presentation-v2/page.tsx
@@ -66,7 +66,7 @@ const SLIDES: Slide[] = [
     eyebrow: "The Problem",
     title: "Hiring broke\nin the AI era.",
     subtitle:
-      "The signals recruiters relied on for 30 years stopped working overnight. Resumes, take-homes, and coding tests are all gameable now.",
+      "Every filter recruiters used to vet candidates stopped working overnight.",
   },
   {
     id: "insight",
@@ -160,33 +160,27 @@ function CoverSlide() {
         <div className="w-[900px] h-[900px] bg-primary/25 rounded-full blur-[180px]" />
       </div>
 
-      <div className="relative z-10 max-w-5xl text-center px-12">
-        <div className="mb-12 flex justify-center">
+      <div className="relative z-10 max-w-5xl text-center px-16">
+        <div className="mb-14 flex justify-center">
           <Image
             src="/skillvee-logo.png"
             alt="SkillVee"
             width={320}
             height={96}
-            style={{ width: "auto", height: 80 }}
+            style={{ width: "auto", height: 88, filter: "brightness(0) invert(1)" }}
             priority
           />
         </div>
 
         <h1 className="text-6xl lg:text-8xl font-black tracking-tight leading-[0.95] text-white mb-8">
-          The future of hiring is{" "}
-          <span className="text-primary">watching people work.</span>
+          Watch them work.
+          <br />
+          <span className="text-primary">Then hire.</span>
         </h1>
 
-        <p className="text-xl lg:text-2xl text-slate-400 font-medium max-w-3xl mx-auto leading-relaxed mb-12">
-          Skillvee runs 45-minute work simulations that show who can actually do the job — before you make the offer.
+        <p className="text-xl lg:text-2xl text-slate-400 font-medium max-w-3xl mx-auto leading-relaxed">
+          See exactly how candidates communicate, collaborate, and solve problems — before you make the offer. No more expensive hiring mistakes.
         </p>
-
-        <div className="inline-flex items-center gap-3 bg-primary/10 border border-primary/40 rounded-full px-6 py-3">
-          <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
-          <span className="text-primary font-bold tracking-wide">
-            Seed round · Raising $1.5M on a SAFE
-          </span>
-        </div>
       </div>
     </div>
   );
@@ -197,40 +191,37 @@ function CoverSlide() {
    ============================================================ */
 
 function ProblemVisual() {
-  const stats = [
-    { value: "1000s/day", label: "Applications per role", icon: FileText, sub: "AI-written, indistinguishable" },
-    { value: "72%", label: "AI-generated resumes", icon: Bot, sub: "up from 12% in 2022" },
-    { value: "<1%", label: "Truly qualified", icon: Target, sub: "after manual screening" },
-    { value: "45%", label: "Use AI in interviews", icon: Sparkles, sub: "even live coding rounds" },
+  const broken = [
+    { label: "Resumes", reason: "AI-written — all look alike" },
+    { label: "Take-homes", reason: "AI-submitted — can't tell who did the work" },
+    { label: "Interviews", reason: "45% of candidates use AI live, undetectable" },
   ];
 
   return (
-    <div className="h-full flex flex-col justify-center gap-5">
-      <div className="grid grid-cols-2 gap-5 flex-1">
-        {stats.map((stat) => {
-          const Icon = stat.icon;
-          return (
+    <div className="h-full flex flex-col justify-center gap-6">
+      <div>
+        <div className="text-xs font-bold uppercase tracking-widest text-slate-500 mb-4">
+          Gameable now
+        </div>
+        <div className="space-y-3">
+          {broken.map((item) => (
             <div
-              key={stat.label}
-              className="bg-slate-800/50 backdrop-blur border border-slate-700/50 rounded-2xl p-7 flex flex-col justify-between"
+              key={item.label}
+              className="flex items-center gap-4 bg-slate-800/40 border border-slate-700/50 rounded-xl p-5"
             >
-              <div className="w-12 h-12 bg-primary/20 rounded-xl flex items-center justify-center">
-                <Icon className="w-6 h-6 text-primary" />
-              </div>
-              <div>
-                <div className="text-5xl font-black text-white mb-2 leading-none">{stat.value}</div>
-                <div className="text-base text-slate-300 font-semibold">{stat.label}</div>
-                <div className="text-xs text-slate-500 mt-1">{stat.sub}</div>
+              <XCircle className="w-7 h-7 text-red-500 flex-shrink-0" />
+              <div className="flex-1">
+                <div className="text-xl font-bold text-slate-200 line-through decoration-red-500/60 decoration-2">{item.label}</div>
+                <div className="text-sm text-slate-400 mt-0.5">{item.reason}</div>
               </div>
             </div>
-          );
-        })}
+          ))}
+        </div>
       </div>
 
       <div className="bg-slate-900/60 border-l-4 border-primary rounded-r-xl p-5">
-        <p className="text-sm text-slate-300 leading-relaxed">
-          <span className="text-white font-semibold">HackerRank bans AI and tests trivia. Take-homes get AI submissions. Resumes are AI slop.</span>{" "}
-          The signals recruiters trusted for 30 years are gone — and nothing has replaced them.
+        <p className="text-base text-slate-200 leading-relaxed font-medium">
+          The signals recruiters trusted for 30 years are gone — and nothing has replaced them yet.
         </p>
       </div>
     </div>
@@ -242,68 +233,22 @@ function ProblemVisual() {
    ============================================================ */
 
 function InsightSlide() {
-  const broken = [
-    { label: "Resumes", reason: "AI-written, all look alike" },
-    { label: "Take-homes", reason: "AI-submitted, can't tell who did the work" },
-    { label: "Coding tests", reason: "Cheated with copilots, banned the tools instead" },
-    { label: "Interviews", reason: "45% candidates use AI live, undetectable" },
-  ];
-
   return (
-    <div className="h-full w-full flex items-center justify-center relative overflow-hidden px-16 py-12">
+    <div className="h-full w-full flex items-center justify-center relative overflow-hidden px-24">
       <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-        <div className="w-[700px] h-[700px] bg-primary/15 rounded-full blur-[160px]" />
+        <div className="w-[900px] h-[900px] bg-primary/20 rounded-full blur-[180px]" />
       </div>
 
-      <div className="relative z-10 max-w-6xl w-full flex flex-col justify-center gap-12">
-        <div className="text-center">
-          <div className="text-xs font-black uppercase tracking-[0.3em] text-primary mb-6">
-            The Insight
-          </div>
-          <h2 className="text-5xl lg:text-7xl font-black tracking-tight leading-[1.05] text-white mb-4">
-            Interviews are going away.
-          </h2>
-          <h2 className="text-5xl lg:text-7xl font-black tracking-tight leading-[1.05] text-primary">
-            Watching people work isn&apos;t gameable.
-          </h2>
+      <div className="relative z-10 max-w-5xl w-full text-center">
+        <div className="text-xs font-black uppercase tracking-[0.3em] text-primary mb-8">
+          The Insight
         </div>
-
-        <div className="grid grid-cols-5 gap-6 items-stretch">
-          <div className="col-span-3">
-            <div className="text-xs font-bold uppercase tracking-widest text-slate-500 mb-4">
-              Gameable now
-            </div>
-            <div className="space-y-3">
-              {broken.map((item) => (
-                <div
-                  key={item.label}
-                  className="flex items-center gap-4 bg-slate-800/40 border border-slate-700/50 rounded-xl p-4"
-                >
-                  <XCircle className="w-6 h-6 text-red-500 flex-shrink-0" />
-                  <div className="flex-1">
-                    <div className="text-lg font-bold text-slate-300 line-through decoration-red-500/60 decoration-2">{item.label}</div>
-                    <div className="text-sm text-slate-500">{item.reason}</div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="col-span-2">
-            <div className="text-xs font-bold uppercase tracking-widest text-primary mb-4">
-              Survives the AI era
-            </div>
-            <div className="bg-gradient-to-br from-primary/20 to-primary/5 border-2 border-primary/50 rounded-xl p-7 h-full flex flex-col justify-center">
-              <CheckCircle2 className="w-10 h-10 text-primary mb-4" />
-              <div className="text-3xl font-black text-white leading-tight mb-3">
-                A 45-min recorded simulation of the actual job.
-              </div>
-              <div className="text-base text-slate-300 leading-relaxed">
-                You can&apos;t fake an hour of work that 10 stakeholders, an AI judge, and a screen recording all witnessed.
-              </div>
-            </div>
-          </div>
-        </div>
+        <h2 className="text-5xl lg:text-7xl font-black tracking-tight leading-[1.1] text-white mb-4">
+          Interviews are going away.
+        </h2>
+        <h2 className="text-5xl lg:text-7xl font-black tracking-tight leading-[1.1] text-white">
+          The future of hiring is <span className="text-primary">watching people work.</span>
+        </h2>
       </div>
     </div>
   );
@@ -907,7 +852,7 @@ function AskSlide() {
   ];
 
   return (
-    <div className="h-full w-full flex items-center justify-center px-16 py-12 relative overflow-hidden">
+    <div className="h-full w-full flex items-center justify-center px-24 py-12 relative overflow-hidden">
       <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
         <div className="w-[800px] h-[800px] bg-primary/25 rounded-full blur-[180px]" />
       </div>
@@ -1090,7 +1035,7 @@ export default function PresentationV2Page() {
           </div>
         ) : (
           <div className="flex w-full">
-            <div className="w-1/2 p-12 lg:p-16 flex flex-col justify-center relative">
+            <div className="w-1/2 pl-16 pr-10 lg:pl-24 lg:pr-14 py-12 flex flex-col justify-center relative">
               <div className="absolute top-[-20%] left-[-20%] w-full h-full bg-primary/15 rounded-full blur-[150px] pointer-events-none" />
               <div className="relative z-10">
                 {slide.eyebrow && (
@@ -1114,7 +1059,7 @@ export default function PresentationV2Page() {
               </div>
             </div>
 
-            <div className="w-1/2 p-8 lg:p-12 flex items-center justify-center">
+            <div className="w-1/2 pl-10 pr-16 lg:pl-14 lg:pr-24 py-12 flex items-center justify-center">
               <div className="w-full h-full">{renderVisual(slide.kind)}</div>
             </div>
           </div>

--- a/src/app/[locale]/product/page.tsx
+++ b/src/app/[locale]/product/page.tsx
@@ -1,67 +1,719 @@
 "use client";
 
+import { useState } from "react";
 import { Link } from "@/i18n/routing";
 import { Button } from "@/components/ui/button";
 import {
-  MessageSquare,
-  Brain,
-  Users,
   ArrowRight,
-  CheckCircle,
-  Video,
   BarChart3,
-  Shield,
-  Lock,
-  Globe,
+  Brain,
+  CheckCircle,
+  CheckCircle2,
   ChevronDown,
-  XCircle,
   Code,
+  Globe,
+  Hash,
+  Lock,
+  MessageSquare,
+  Phone,
+  PhoneOff,
+  Send,
+  Shield,
+  Sparkles,
+  Users,
+  Video,
+  XCircle,
 } from "lucide-react";
-import Footer from "@/components/landing/footer";
-import Navigation from "@/components/landing/navigation";
-import { SectionReveal } from "@/components/landing/section-reveal";
-import { CurveDivider } from "@/components/landing/section-divider";
-import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { useTranslations } from "next-intl";
 
-const FeatureCard = ({ icon: Icon, title, text, iconColor }: { icon: React.ComponentType<{ className?: string }>, title: string, text: string, iconColor: string }) => (
-    <motion.div
-        initial={{ opacity: 0, scale: 0.95 }}
-        whileInView={{ opacity: 1, scale: 1 }}
-        viewport={{ once: true }}
-        transition={{ delay: 0.1 }}
-        className="bg-slate-50 border border-slate-200 rounded-2xl p-6 flex flex-col items-start hover:border-primary/30 hover:shadow-lg transition-all"
-    >
-        <div className={`w-12 h-12 rounded-lg flex items-center justify-center mb-4 bg-${iconColor}-500/10`}>
-            <Icon className={`w-6 h-6 text-${iconColor}-600`} />
+import Footer from "@/components/landing/footer";
+import Navigation from "@/components/landing/navigation";
+import { CurveDivider } from "@/components/landing/section-divider";
+import { SectionReveal } from "@/components/landing/section-reveal";
+
+/* ============================================================
+   MOCKUP: Voice call (Sarah Chen) — used in hero composite and step 1
+   ============================================================ */
+function VoiceCallMock({ compact = false }: { compact?: boolean }) {
+  const t = useTranslations("product");
+  const sizeCls = compact ? "max-w-[300px]" : "max-w-md";
+  const avatarCls = compact ? "w-16 h-16 text-2xl" : "w-24 h-24 text-3xl";
+  const ringSmall = compact ? "w-24 h-24" : "w-32 h-32";
+  const ringLarge = compact ? "w-32 h-32" : "w-40 h-40";
+
+  return (
+    <div className={`w-full ${sizeCls}`}>
+      <div className="relative overflow-hidden rounded-3xl bg-slate-900 p-8 text-center shadow-2xl ring-1 ring-white/10">
+        {/* Animated rings */}
+        <motion.div
+          animate={{ scale: [1, 1.5, 1], opacity: [0.3, 0, 0.3] }}
+          transition={{ duration: 2, repeat: Infinity }}
+          className="pointer-events-none absolute inset-0 flex items-center justify-center"
+        >
+          <div className={`${ringLarge} rounded-full border-2 border-primary/30`} />
+        </motion.div>
+        <motion.div
+          animate={{ scale: [1, 1.3, 1], opacity: [0.5, 0, 0.5] }}
+          transition={{ duration: 2, repeat: Infinity, delay: 0.3 }}
+          className="pointer-events-none absolute inset-0 flex items-center justify-center"
+        >
+          <div className={`${ringSmall} rounded-full border-2 border-primary/50`} />
+        </motion.div>
+
+        {/* Avatar */}
+        <div className="relative z-10 mb-6">
+          <motion.div
+            animate={{ scale: [1, 1.05, 1] }}
+            transition={{ duration: 1.5, repeat: Infinity }}
+            className={`${avatarCls} mx-auto flex items-center justify-center rounded-full bg-gradient-to-br from-emerald-400 to-emerald-600 font-bold text-white shadow-xl shadow-emerald-500/30`}
+          >
+            S
+          </motion.div>
+          <motion.div
+            animate={{ opacity: [1, 0.5, 1] }}
+            transition={{ duration: 1, repeat: Infinity }}
+            className="absolute bottom-1 right-1/2 h-4 w-4 translate-x-8 rounded-full border-2 border-slate-900 bg-green-500"
+          />
         </div>
-        <h3 className="text-lg font-bold text-slate-900 mb-2">{title}</h3>
-        <p className="text-slate-600 text-sm">{text}</p>
+
+        <h3 className="text-xl font-bold text-white">Sarah Chen</h3>
+        <p className="mb-2 text-sm text-slate-400">{t("voiceCall.role")}</p>
+
+        {/* Voice indicator — fixed height reserves max bar size so layout stays stable */}
+        <div className="mb-6 flex h-5 items-center justify-center gap-1">
+          {[...Array(5)].map((_, i) => (
+            <motion.div
+              key={i}
+              animate={{ height: [8, 20, 8] }}
+              transition={{ duration: 0.5, repeat: Infinity, delay: i * 0.1 }}
+              className="w-1 rounded-full bg-primary"
+              style={{ height: 8 }}
+            />
+          ))}
+        </div>
+
+        <p className="mb-6 text-xs text-slate-500">{t("voiceCall.callInProgress")}</p>
+
+        {/* Controls */}
+        <div className="flex items-center justify-center gap-4">
+          <div className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-slate-800">
+            <Phone className="h-5 w-5 text-slate-400" />
+          </div>
+          <motion.div
+            animate={{ scale: [1, 1.05, 1] }}
+            transition={{ duration: 1, repeat: Infinity }}
+            className="flex h-14 w-14 cursor-pointer items-center justify-center rounded-full bg-red-500 shadow-lg shadow-red-500/30"
+          >
+            <PhoneOff className="h-6 w-6 text-white" />
+          </motion.div>
+          <div className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-slate-800">
+            <Sparkles className="h-5 w-5 text-slate-400" />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center justify-center gap-2 text-xs text-slate-500">
+        <div className="h-4 w-4 rounded bg-gradient-to-br from-blue-500 via-purple-500 to-pink-500" />
+        {t("voiceCall.poweredBy")}
+      </div>
+    </div>
+  );
+}
+
+/* ============================================================
+   MOCKUP: IDE with recording (step 2)
+   ============================================================ */
+type Tok = { t: string; c?: string };
+
+function IdeRecordingMock() {
+  const t = useTranslations("product");
+  const K = "text-purple-400";  // keywords
+  const F = "text-sky-300";     // function names
+  const S = "text-emerald-300"; // strings
+  const N = "text-amber-300";   // numbers
+  const T = "text-cyan-300";    // types
+  const C = "text-slate-500 italic"; // comments
+  const P = "text-slate-300";   // plain
+
+  const code: Tok[][] = [
+    [{ t: "// Fix: guard against expired cart sessions", c: C }],
+    [
+      { t: "export ", c: K },
+      { t: "async function ", c: K },
+      { t: "checkout", c: F },
+      { t: "(" },
+      { t: "cartId", c: P },
+      { t: ": " },
+      { t: "string", c: T },
+      { t: ") {" },
+    ],
+    [
+      { t: "  const ", c: K },
+      { t: "cart", c: P },
+      { t: " = ", c: P },
+      { t: "await ", c: K },
+      { t: "redis", c: P },
+      { t: ".", c: P },
+      { t: "get", c: F },
+      { t: "(" },
+      { t: "`cart:${cartId}`", c: S },
+      { t: ");" },
+    ],
+    [
+      { t: "  if ", c: K },
+      { t: "(!cart || cart.", c: P },
+      { t: "expiresAt", c: P },
+      { t: " < ", c: P },
+      { t: "Date", c: T },
+      { t: ".", c: P },
+      { t: "now", c: F },
+      { t: "()) {" },
+    ],
+    [
+      { t: "    throw new ", c: K },
+      { t: "CartExpiredError", c: T },
+      { t: "(", c: P },
+      { t: "cartId", c: P },
+      { t: ");" },
+    ],
+    [{ t: "  }" }],
+    [
+      { t: "  return ", c: K },
+      { t: "stripe", c: P },
+      { t: ".", c: P },
+      { t: "charge", c: F },
+      { t: "(cart.", c: P },
+      { t: "total", c: P },
+      { t: ", ", c: P },
+      { t: "3000", c: N },
+      { t: ");" },
+    ],
+    [{ t: "}" }],
+  ];
+
+  return (
+    <div className="relative w-full max-w-xl">
+      {/* Main IDE window */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        className="overflow-hidden rounded-2xl bg-slate-900 shadow-2xl ring-1 ring-white/10"
+      >
+        {/* Title bar */}
+        <div className="flex items-center gap-2 border-b border-slate-800 bg-slate-950 px-4 py-3">
+          <div className="flex gap-1.5">
+            <div className="h-2.5 w-2.5 rounded-full bg-red-500" />
+            <div className="h-2.5 w-2.5 rounded-full bg-yellow-500" />
+            <div className="h-2.5 w-2.5 rounded-full bg-green-500" />
+          </div>
+          <div className="ml-3 text-xs text-slate-500">checkout.ts — skillvee</div>
+          <div className="ml-auto flex items-center gap-1.5 rounded bg-red-500/90 px-2 py-1">
+            <motion.div
+              animate={{ opacity: [1, 0.3, 1] }}
+              transition={{ duration: 1, repeat: Infinity }}
+              className="h-1.5 w-1.5 rounded-full bg-white"
+            />
+            <span className="text-[10px] font-bold text-white">REC</span>
+          </div>
+        </div>
+
+        {/* Editor area */}
+        <div className="flex font-mono text-[12px] leading-[1.7]">
+          {/* Line numbers */}
+          <div className="flex flex-col border-r border-slate-800 bg-slate-950 px-3 py-4 text-right text-[11px] text-slate-600">
+            {code.map((_, i) => (
+              <span key={i}>{i + 1}</span>
+            ))}
+          </div>
+          {/* Code */}
+          <div className="flex-1 overflow-hidden py-4 pl-4 pr-3">
+            {code.map((line, i) => (
+              <motion.div
+                key={i}
+                initial={{ opacity: 0, x: -6 }}
+                whileInView={{ opacity: 1, x: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: 0.1 + i * 0.08, duration: 0.25 }}
+                className="whitespace-pre"
+              >
+                {line.map((tok, j) => (
+                  <span key={j} className={tok.c ?? P}>
+                    {tok.t}
+                  </span>
+                ))}
+                {/* Cursor on the last non-empty line */}
+                {i === code.length - 2 && (
+                  <motion.span
+                    animate={{ opacity: [1, 0, 1] }}
+                    transition={{ duration: 1, repeat: Infinity }}
+                    className="inline-block h-3.5 w-0.5 translate-y-0.5 bg-primary align-middle"
+                  />
+                )}
+              </motion.div>
+            ))}
+          </div>
+        </div>
+
+        {/* Status bar */}
+        <div className="flex items-center gap-3 border-t border-slate-800 bg-slate-950 px-4 py-2 text-[10px] text-slate-500">
+          <span className="flex items-center gap-1">
+            <div className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            main
+          </span>
+          <span>TypeScript</span>
+          <span className="ml-auto">{t("ide.recordingStatus")}</span>
+        </div>
+      </motion.div>
+
+      {/* Floating call bar (lower-right) */}
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ delay: 0.4 }}
+        className="absolute -bottom-6 -right-2 flex items-center gap-3 rounded-full bg-slate-900 py-2.5 pl-2.5 pr-5 shadow-2xl ring-1 ring-white/10"
+      >
+        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-emerald-400 to-emerald-600 text-sm font-bold text-white">
+          S
+        </div>
+        <div className="flex flex-col">
+          <span className="text-xs font-semibold text-white">Sarah Chen</span>
+          <div className="flex items-center gap-1">
+            {[...Array(4)].map((_, i) => (
+              <motion.div
+                key={i}
+                animate={{ height: [4, 10, 4] }}
+                transition={{ duration: 0.6, repeat: Infinity, delay: i * 0.1 }}
+                className="w-0.5 rounded-full bg-primary"
+                style={{ height: 4 }}
+              />
+            ))}
+            <span className="ml-1 text-[10px] text-slate-400">{t("ide.onCall")}</span>
+          </div>
+        </div>
+        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-red-500">
+          <PhoneOff className="h-3.5 w-3.5 text-white" />
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+/* ============================================================
+   MOCKUP: Slack-thread (step 3 — present and defend)
+   ============================================================ */
+function DefendThreadMock() {
+  const t = useTranslations("product");
+  const youLabel = t("defendThread.you");
+  const messages = [
+    { from: "Sarah Chen", isYou: false, text: t("defendThread.msg1") },
+    { from: youLabel, isYou: true, text: t("defendThread.msg2") },
+    { from: "Sarah Chen", isYou: false, text: t("defendThread.msg3") },
+    { from: youLabel, isYou: true, text: t("defendThread.msg4") },
+  ];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      whileInView={{ opacity: 1, scale: 1 }}
+      viewport={{ once: true }}
+      className="w-full max-w-xl overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl"
+    >
+      {/* Header */}
+      <div className="flex h-12 items-center gap-2 border-b border-slate-200 px-4">
+        <Hash className="h-4 w-4 text-slate-400" />
+        <span className="text-sm font-semibold text-slate-900">sarah-chen</span>
+        <span className="text-xs text-slate-400">· {t("defendThread.role")}</span>
+        <div className="ml-auto flex items-center gap-1.5 rounded-full bg-amber-50 px-2 py-1 text-[10px] font-semibold text-amber-700">
+          <div className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+          {t("defendThread.defendingDecisions")}
+        </div>
+      </div>
+
+      {/* Messages */}
+      <div className="space-y-3 p-4">
+        {messages.map((msg, i) => (
+          <motion.div
+            key={i}
+            initial={{ opacity: 0, y: 8 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.15 + i * 0.15 }}
+            className={`flex gap-2.5 ${msg.isYou ? "flex-row-reverse" : ""}`}
+          >
+            <div
+              className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg text-[10px] font-bold text-white ${
+                msg.isYou ? "bg-primary" : "bg-emerald-500"
+              }`}
+            >
+              {msg.isYou ? youLabel[0] : "S"}
+            </div>
+            <div className={`max-w-[75%] ${msg.isYou ? "text-right" : ""}`}>
+              <div className="mb-0.5 text-[10px] font-semibold text-slate-900">{msg.from}</div>
+              <div
+                className={`inline-block rounded-lg p-2.5 text-xs leading-relaxed text-slate-700 ${
+                  msg.isYou ? "bg-primary/10 text-left" : "bg-slate-100"
+                }`}
+              >
+                {msg.text}
+              </div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Input */}
+      <div className="flex h-14 items-center gap-2 border-t border-slate-200 px-4">
+        <div className="flex-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-400">
+          {t("defendThread.replyPlaceholder")}
+        </div>
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary">
+          <Send className="h-4 w-4 text-white" />
+        </div>
+      </div>
     </motion.div>
+  );
+}
+
+/* ============================================================
+   MOCKUP: Hiring-manager dashboard — ranked candidates + evidence
+   ============================================================ */
+function HiringManagerMock() {
+  const t = useTranslations("product");
+  const candidates = [
+    { name: "Priya Patel", overall: 4.4, selected: true, tag: t("hiringManagers.mock.topMatch") },
+    { name: "John Smith", overall: 4.1 },
+    { name: "Emma Wong", overall: 3.8 },
+    { name: "Mike Liu", overall: 3.5 },
+  ];
+
+  const dimensions = [
+    { name: t("hiringManagers.mock.dimensions.problemSolving"), score: 4.6, color: "bg-emerald-500" },
+    { name: t("hiringManagers.mock.dimensions.aiLeverage"), score: 4.5, color: "bg-emerald-500" },
+    { name: t("hiringManagers.mock.dimensions.communication"), score: 4.3, color: "bg-blue-500" },
+    { name: t("hiringManagers.mock.dimensions.technicalDepth"), score: 4.1, color: "bg-blue-500" },
+    { name: t("hiringManagers.mock.dimensions.collaboration"), score: 4.4, color: "bg-blue-500" },
+    { name: t("hiringManagers.mock.dimensions.timeManagement"), score: 3.9, color: "bg-amber-500" },
+  ];
+
+  const evidence = [
+    {
+      dim: t("hiringManagers.mock.dimensions.problemSolving"),
+      ts: "02:14",
+      quote: t("hiringManagers.mock.evidence1"),
+    },
+    {
+      dim: t("hiringManagers.mock.dimensions.technicalDepth"),
+      ts: "18:42",
+      quote: t("hiringManagers.mock.evidence2"),
+    },
+    {
+      dim: t("hiringManagers.mock.dimensions.communication"),
+      ts: "24:50",
+      quote: t("hiringManagers.mock.evidence3"),
+    },
+  ];
+
+  return (
+    <div className="grid w-full grid-cols-1 gap-6 lg:grid-cols-[320px,1fr]">
+      {/* LEFT: ranked list */}
+      <motion.div
+        initial={{ opacity: 0, x: -12 }}
+        whileInView={{ opacity: 1, x: 0 }}
+        viewport={{ once: true }}
+        className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+      >
+        <div className="mb-4 flex items-center justify-between px-2">
+          <div>
+            <h4 className="text-sm font-bold text-slate-900">{t("hiringManagers.mock.role")}</h4>
+            <div className="text-[10px] text-slate-500">{t("hiringManagers.mock.rankedByOverall")}</div>
+          </div>
+          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-600">
+            {t("hiringManagers.mock.completed")}
+          </span>
+        </div>
+        <div className="space-y-1.5">
+          {candidates.map((c, i) => (
+            <motion.div
+              key={c.name}
+              initial={{ opacity: 0, y: 6 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: 0.1 + i * 0.08 }}
+              className={`flex items-center gap-3 rounded-xl p-2.5 ${
+                c.selected ? "bg-primary/5 ring-2 ring-primary/30" : ""
+              }`}
+            >
+              <span className="w-4 text-center text-xs font-bold text-slate-400">{i + 1}</span>
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-blue-600 text-[11px] font-bold text-white">
+                {c.name[0]}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5">
+                  <span className="truncate text-xs font-semibold text-slate-900">{c.name}</span>
+                  {c.tag && (
+                    <span className="flex-shrink-0 rounded bg-emerald-100 px-1.5 py-0.5 text-[9px] font-bold text-emerald-700">
+                      {c.tag}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-1 h-1 w-full overflow-hidden rounded-full bg-slate-100">
+                  <div
+                    className={`h-full rounded-full ${c.selected ? "bg-primary" : "bg-slate-300"}`}
+                    style={{ width: `${(c.overall / 5) * 100}%` }}
+                  />
+                </div>
+              </div>
+              <div
+                className={`text-sm font-black ${c.selected ? "text-primary" : "text-slate-700"}`}
+              >
+                {c.overall.toFixed(1)}
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </motion.div>
+
+      {/* RIGHT: scorecard + evidence */}
+      <div className="flex flex-col gap-4">
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+        >
+          <div className="mb-5 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-primary to-blue-600 text-base font-bold text-white">
+                P
+              </div>
+              <div>
+                <div className="text-base font-bold text-slate-900">Priya Patel</div>
+                <div className="text-xs text-slate-500">{t("hiringManagers.mock.candidateRoleTime")}</div>
+              </div>
+            </div>
+            <div className="text-right">
+              <div className="text-3xl font-black leading-none text-primary">4.4</div>
+              <div className="mt-0.5 text-[10px] text-slate-500">{t("hiringManagers.mock.overall")}</div>
+            </div>
+          </div>
+
+          <div className="space-y-2.5">
+            {dimensions.map((d, i) => (
+              <motion.div
+                key={d.name}
+                initial={{ opacity: 0, x: -6 }}
+                whileInView={{ opacity: 1, x: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: 0.15 + i * 0.07 }}
+                className="flex items-center gap-3"
+              >
+                <div className="w-32 flex-shrink-0 text-xs font-medium text-slate-700">
+                  {d.name}
+                </div>
+                <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-100">
+                  <motion.div
+                    initial={{ width: 0 }}
+                    whileInView={{ width: `${(d.score / 5) * 100}%` }}
+                    viewport={{ once: true }}
+                    transition={{ delay: 0.25 + i * 0.07, duration: 0.6 }}
+                    className={`h-full rounded-full ${d.color}`}
+                  />
+                </div>
+                <div className="w-8 text-right text-xs font-bold text-slate-700">{d.score}</div>
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+
+        {/* Evidence card */}
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ delay: 0.3 }}
+          className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+        >
+          <div className="mb-3 flex items-center gap-2">
+            <div className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            <span className="text-[10px] font-bold uppercase tracking-widest text-slate-500">
+              {t("hiringManagers.mock.observedEvidence")}
+            </span>
+          </div>
+          <div className="space-y-2">
+            {evidence.map((e, i) => (
+              <motion.div
+                key={i}
+                initial={{ opacity: 0, y: 6 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: 0.45 + i * 0.1 }}
+                className="flex gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3"
+              >
+                <span className="flex-shrink-0 rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[10px] font-bold text-primary">
+                  {e.ts}
+                </span>
+                <div className="flex-1">
+                  <div className="mb-0.5 text-[10px] font-semibold text-slate-500">{e.dim}</div>
+                  <div className="text-xs leading-relaxed text-slate-700">{e.quote}</div>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+}
+
+/* ============================================================
+   MOCKUP: Hero composite — layered chat + voice call + IDE peek
+   ============================================================ */
+function HeroComposite() {
+  const t = useTranslations("product");
+  return (
+    <div className="relative mx-auto h-[520px] w-full max-w-4xl">
+      {/* Back: IDE peek (top-left, rotated) */}
+      <motion.div
+        initial={{ opacity: 0, y: 20, rotate: -6 }}
+        animate={{ opacity: 1, y: 0, rotate: -6 }}
+        transition={{ delay: 0.2, duration: 0.6 }}
+        className="absolute left-0 top-6 w-72 origin-bottom-right overflow-hidden rounded-xl bg-slate-900 shadow-2xl ring-1 ring-white/10"
+      >
+        <div className="flex items-center gap-1.5 border-b border-slate-800 bg-slate-950 px-3 py-2">
+          <div className="h-2 w-2 rounded-full bg-red-500" />
+          <div className="h-2 w-2 rounded-full bg-yellow-500" />
+          <div className="h-2 w-2 rounded-full bg-green-500" />
+          <span className="ml-2 text-[10px] text-slate-500">checkout.ts</span>
+          <div className="ml-auto flex items-center gap-1 rounded bg-red-500/90 px-1.5 py-0.5">
+            <motion.div
+              animate={{ opacity: [1, 0.3, 1] }}
+              transition={{ duration: 1, repeat: Infinity }}
+              className="h-1 w-1 rounded-full bg-white"
+            />
+            <span className="text-[8px] font-bold text-white">REC</span>
+          </div>
+        </div>
+        <div className="space-y-1.5 p-3">
+          {[60, 40, 75, 50, 65].map((w, i) => (
+            <div
+              key={i}
+              className={`h-1.5 rounded ${
+                i === 0 ? "bg-purple-500/60" : i === 2 ? "bg-emerald-500/60" : "bg-slate-700"
+              }`}
+              style={{ width: `${w}%` }}
+            />
+          ))}
+        </div>
+      </motion.div>
+
+      {/* Middle: Slack chat (center-left, focal) */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.35, duration: 0.6 }}
+        className="absolute left-24 top-28 z-10 w-[360px] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl"
+      >
+        <div className="flex h-10 items-center gap-2 border-b border-slate-200 bg-slate-50 px-4">
+          <Hash className="h-3.5 w-3.5 text-slate-400" />
+          <span className="text-xs font-semibold text-slate-900">sarah-chen</span>
+          <span className="text-[10px] text-slate-400">{t("hero.chatRole")}</span>
+        </div>
+        <div className="space-y-2.5 p-4">
+          <div className="flex gap-2">
+            <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg bg-emerald-500 text-[10px] font-bold text-white">
+              S
+            </div>
+            <div className="flex-1">
+              <div className="text-[10px] font-semibold text-slate-900">Sarah Chen</div>
+              <div className="mt-0.5 rounded-lg bg-slate-100 p-2 text-xs text-slate-700">
+                {t("hero.chatMsg1")}
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-row-reverse gap-2">
+            <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg bg-primary text-[10px] font-bold text-white">
+              {t("hero.chatYou")[0]}
+            </div>
+            <div className="flex-1 text-right">
+              <div className="text-[10px] font-semibold text-slate-900">{t("hero.chatYou")}</div>
+              <div className="mt-0.5 inline-block rounded-lg bg-primary/10 p-2 text-left text-xs text-slate-700">
+                {t("hero.chatMsg2")}
+              </div>
+            </div>
+          </div>
+          <motion.div
+            animate={{ scale: [1, 1.03, 1] }}
+            transition={{ duration: 2, repeat: Infinity }}
+            className="mt-2 flex items-center justify-center gap-2 rounded-lg bg-primary py-2 text-xs font-bold text-white"
+          >
+            <Phone className="h-3.5 w-3.5" /> {t("hero.startCall")}
+          </motion.div>
+        </div>
+      </motion.div>
+
+      {/* Front: Voice call (bottom-right) */}
+      <motion.div
+        initial={{ opacity: 0, y: 20, rotate: 4 }}
+        animate={{ opacity: 1, y: 0, rotate: 4 }}
+        transition={{ delay: 0.5, duration: 0.6 }}
+        className="absolute bottom-4 right-0 z-20 w-[280px] origin-top-left"
+      >
+        <VoiceCallMock compact />
+      </motion.div>
+    </div>
+  );
+}
+
+/* ============================================================
+   FEATURES GRID CARD
+   ============================================================ */
+const FeatureCard = ({
+  icon: Icon,
+  title,
+  text,
+  iconBg,
+  iconColor,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  text: string;
+  iconBg: string;
+  iconColor: string;
+}) => (
+  <motion.div
+    initial={{ opacity: 0, y: 16 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true }}
+    transition={{ duration: 0.4 }}
+    className="rounded-2xl border border-slate-200 bg-white p-6 transition-all hover:border-primary/30 hover:shadow-lg"
+  >
+    <div className={`mb-4 flex h-12 w-12 items-center justify-center rounded-xl ${iconBg}`}>
+      <Icon className={`h-6 w-6 ${iconColor}`} />
+    </div>
+    <h3 className="mb-2 text-lg font-bold text-slate-900">{title}</h3>
+    <p className="text-sm leading-relaxed text-slate-600">{text}</p>
+  </motion.div>
 );
 
+/* ============================================================
+   FAQ
+   ============================================================ */
 function ProductFAQ() {
   const t = useTranslations("product");
   const [openIndex, setOpenIndex] = useState<number | null>(0);
 
   const faqs = [
-    {
-      question: t("faq.q1.question"),
-      answer: t("faq.q1.answer"),
-    },
-    {
-      question: t("faq.q2.question"),
-      answer: t("faq.q2.answer"),
-    },
-    {
-      question: t("faq.q3.question"),
-      answer: t("faq.q3.answer"),
-    },
-    {
-      question: t("faq.q4.question"),
-      answer: t("faq.q4.answer"),
-    },
+    { question: t("faq.q1.question"), answer: t("faq.q1.answer") },
+    { question: t("faq.q5.question"), answer: t("faq.q5.answer") },
+    { question: t("faq.q6.question"), answer: t("faq.q6.answer") },
+    { question: t("faq.q2.question"), answer: t("faq.q2.answer") },
+    { question: t("faq.q7.question"), answer: t("faq.q7.answer") },
+    { question: t("faq.q8.question"), answer: t("faq.q8.answer") },
+    { question: t("faq.q3.question"), answer: t("faq.q3.answer") },
+    { question: t("faq.q4.question"), answer: t("faq.q4.answer") },
   ];
 
   return (
@@ -69,27 +721,27 @@ function ProductFAQ() {
       {faqs.map((faq, index) => (
         <div
           key={index}
-          className="bg-white border-2 border-slate-200 hover:border-primary/30 rounded-2xl overflow-hidden transition-all duration-300 hover:shadow-lg"
+          className="overflow-hidden rounded-2xl border-2 border-slate-200 bg-white transition-all duration-300 hover:border-primary/30 hover:shadow-lg"
         >
           <button
-            className="w-full px-6 py-5 text-left flex items-center justify-between hover:bg-slate-50 transition-colors"
+            className="flex w-full items-center justify-between px-6 py-5 text-left transition-colors hover:bg-slate-50"
             onClick={() => setOpenIndex(openIndex === index ? null : index)}
           >
-            <div className="flex items-start space-x-4 flex-1">
-              <div className="w-8 h-8 bg-primary/10 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
-                <span className="text-primary font-bold text-sm">Q</span>
+            <div className="flex flex-1 items-start space-x-4">
+              <div className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-primary/10">
+                <span className="text-sm font-bold text-primary">Q</span>
               </div>
-              <h3 className="font-semibold text-slate-900 text-lg pr-4">{faq.question}</h3>
+              <h3 className="pr-4 text-lg font-semibold text-slate-900">{faq.question}</h3>
             </div>
             <ChevronDown
-              className={`w-5 h-5 text-slate-400 flex-shrink-0 transition-transform duration-300 ${
+              className={`h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-300 ${
                 openIndex === index ? "rotate-180" : ""
               }`}
             />
           </button>
           {openIndex === index && (
-            <div className="px-6 pb-5 animate-in fade-in duration-200">
-              <div className="pl-12 text-slate-600 leading-relaxed">{faq.answer}</div>
+            <div className="animate-in fade-in px-6 pb-5 duration-200">
+              <div className="pl-12 leading-relaxed text-slate-600">{faq.answer}</div>
             </div>
           )}
         </div>
@@ -98,318 +750,568 @@ function ProductFAQ() {
   );
 }
 
-export default function ProductPage() {
-    const t = useTranslations("product");
-    const [activeStep, setActiveStep] = useState(0);
+/* ============================================================
+   PAGE
+   ============================================================ */
+export default function ProductV2Page() {
+  const t = useTranslations("product");
+  const [activeStep, setActiveStep] = useState(0);
 
-    const timelineSteps = [
-        {
-            icon: Users,
-            title: t("timeline.step1.title"),
-            description: t("timeline.step1.description"),
-            tags: [t("timeline.step1.tag1"), t("timeline.step1.tag2")],
-            video: "/videos/product-step1.mp4"
-        },
-        {
-            icon: Code,
-            title: t("timeline.step2.title"),
-            description: t("timeline.step2.description"),
-            tags: [t("timeline.step2.tag1"), t("timeline.step2.tag2"), t("timeline.step2.tag3")],
-            video: "/videos/product-step2.mp4"
-        },
-        {
-            icon: MessageSquare,
-            title: t("timeline.step3.title"),
-            description: t("timeline.step3.description"),
-            tags: [t("timeline.step3.tag1"), t("timeline.step3.tag2")],
-            video: "/videos/product-step3.mp4"
-        }
-    ];
+  const stepMocks = [<VoiceCallMock key="call" />, <IdeRecordingMock key="ide" />, <DefendThreadMock key="defend" />];
 
-    const comparisonData = [
-        {
-            feature: t("comparison.signalQuality.title"),
-            oldWay: t("comparison.signalQuality.oldWay"),
-            skillveeWay: t("comparison.signalQuality.skillveeWay")
-        },
-        {
-            feature: t("comparison.candidateExperience.title"),
-            oldWay: t("comparison.candidateExperience.oldWay"),
-            skillveeWay: t("comparison.candidateExperience.skillveeWay")
-        },
-        {
-            feature: t("comparison.timeToHire.title"),
-            oldWay: t("comparison.timeToHire.oldWay"),
-            skillveeWay: t("comparison.timeToHire.skillveeWay")
-        },
-        {
-            feature: t("comparison.bias.title"),
-            oldWay: t("comparison.bias.oldWay"),
-            skillveeWay: t("comparison.bias.skillveeWay")
-        }
-    ];
+  const timelineSteps = [
+    {
+      icon: Users,
+      title: t("timeline.step1.title"),
+      description: t("timeline.step1.description"),
+      tags: [t("timeline.step1.tag1"), t("timeline.step1.tag2")],
+    },
+    {
+      icon: Code,
+      title: t("timeline.step2.title"),
+      description: t("timeline.step2.description"),
+      tags: [t("timeline.step2.tag1"), t("timeline.step2.tag2"), t("timeline.step2.tag3")],
+    },
+    {
+      icon: MessageSquare,
+      title: t("timeline.step3.title"),
+      description: t("timeline.step3.description"),
+      tags: [t("timeline.step3.tag1"), t("timeline.step3.tag2")],
+    },
+  ];
+
+  const comparisonData = [
+    {
+      feature: t("comparison.signalQuality.title"),
+      oldWay: t("comparison.signalQuality.oldWay"),
+      skillveeWay: t("comparison.signalQuality.skillveeWay"),
+    },
+    {
+      feature: t("comparison.candidateExperience.title"),
+      oldWay: t("comparison.candidateExperience.oldWay"),
+      skillveeWay: t("comparison.candidateExperience.skillveeWay"),
+    },
+    {
+      feature: t("comparison.timeToHire.title"),
+      oldWay: t("comparison.timeToHire.oldWay"),
+      skillveeWay: t("comparison.timeToHire.skillveeWay"),
+    },
+    {
+      feature: t("comparison.bias.title"),
+      oldWay: t("comparison.bias.oldWay"),
+      skillveeWay: t("comparison.bias.skillveeWay"),
+    },
+  ];
 
   return (
     <div className="min-h-screen bg-white text-slate-900">
-      {/* Dark Hero Section */}
-      <div className="bg-[#020617] relative overflow-hidden">
+      {/* ============================================
+          HERO — dark with composite mockup
+          ============================================ */}
+      <div className="relative overflow-hidden bg-[#020617]">
         <Navigation variant="dark" currentPage="product" />
 
-        {/* Animated background glows */}
+        {/* Ambient glows */}
         <motion.div
-          animate={{
-            scale: [1, 1.2, 1],
-            opacity: [0.1, 0.2, 0.1],
-          }}
+          animate={{ scale: [1, 1.2, 1], opacity: [0.1, 0.2, 0.1] }}
           transition={{ duration: 15, repeat: Infinity, ease: "easeInOut" }}
-          className="absolute top-0 right-0 w-[600px] h-[600px] bg-primary/30 rounded-full blur-[200px] pointer-events-none"
+          className="pointer-events-none absolute right-0 top-0 h-[600px] w-[600px] rounded-full bg-primary/30 blur-[200px]"
         />
         <motion.div
-          animate={{
-            scale: [1.2, 1, 1.2],
-            opacity: [0.08, 0.15, 0.08],
-          }}
+          animate={{ scale: [1.2, 1, 1.2], opacity: [0.08, 0.15, 0.08] }}
           transition={{ duration: 18, repeat: Infinity, ease: "easeInOut" }}
-          className="absolute bottom-0 left-0 w-[500px] h-[500px] bg-indigo-500/20 rounded-full blur-[200px] pointer-events-none"
+          className="pointer-events-none absolute bottom-0 left-0 h-[500px] w-[500px] rounded-full bg-indigo-500/20 blur-[200px]"
         />
 
-        {/* Hero Section */}
-        <section className="relative pt-32 pb-20">
-          <div className="relative z-10 max-w-7xl mx-auto px-6 sm:px-8 lg:px-6 text-center">
+        <section className="relative pb-24 pt-32">
+          <div className="relative z-10 mx-auto max-w-7xl px-6 sm:px-8 lg:px-6">
             <motion.div
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8 }}
+              className="text-center"
             >
-              <div className="inline-flex items-center gap-2 bg-white/5 border border-white/10 rounded-full px-4 py-2 mb-6">
-                <span className="w-2 h-2 bg-emerald-400 rounded-full animate-pulse" />
-                <span className="text-slate-400 text-sm">{t("hero.badge")}</span>
-              </div>
-
-              <h1 className="text-4xl sm:text-5xl lg:text-6xl font-black text-white leading-tight mb-6">
+              <h1 className="mb-6 text-4xl font-black leading-tight text-white sm:text-5xl lg:text-6xl">
                 {t("hero.title")}
                 <br />
                 <span className="text-primary">{t("hero.titleHighlight")}</span>
               </h1>
 
-              <p className="text-xl text-slate-400 max-w-2xl mx-auto mb-12">
-                {t("hero.subtitle")}
-              </p>
-            </motion.div>
+              <p className="mx-auto mb-8 max-w-2xl text-xl text-slate-400">{t("hero.subtitle")}</p>
 
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, delay: 0.2 }}
-              className="max-w-5xl mx-auto"
-            >
-              <div className="relative rounded-2xl overflow-hidden shadow-2xl shadow-primary/20 ring-1 ring-white/15">
-                {/* Ambient glow effect */}
-                <div className="absolute -inset-2 bg-gradient-to-r from-primary/30 via-primary/10 to-primary/30 blur-2xl opacity-60" />
-
-                <div className="relative aspect-video bg-slate-900 overflow-hidden">
-                  <video
-                    className="absolute inset-0 w-full h-full object-cover"
-                    autoPlay
-                    loop
-                    muted
-                    playsInline
+              {/* Roles signal — makes it clear this isn't engineering-only */}
+              <div className="mx-auto mb-16 flex max-w-3xl flex-wrap items-center justify-center gap-x-3 gap-y-2 text-xs sm:text-sm text-slate-400">
+                <span className="text-slate-500">{t("hero.rolesLabel")}</span>
+                {[
+                  t("hero.roles.engineering"),
+                  t("hero.roles.product"),
+                  t("hero.roles.dataScience"),
+                  t("hero.roles.sales"),
+                  t("hero.roles.customerSuccess"),
+                ].map((role) => (
+                  <span
+                    key={role}
+                    className="rounded-full border border-white/10 bg-white/5 px-3 py-1 font-medium text-slate-300"
                   >
-                    <source src="/videos/product-demo.mp4" type="video/mp4" />
-                  </video>
-
-                  {/* Subtle edge vignette to lift video from background */}
-                  <div className="absolute inset-0 ring-1 ring-inset ring-white/10 rounded-2xl pointer-events-none" />
-                </div>
+                    {role}
+                  </span>
+                ))}
               </div>
             </motion.div>
+
+            <HeroComposite />
           </div>
         </section>
       </div>
 
-      {/* Interactive Timeline Section */}
-      <section className="relative py-20 sm:py-24 bg-slate-50">
-        <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-6">
-            <SectionReveal className="text-center mb-16">
-                <h2 className="text-3xl sm:text-4xl font-bold text-slate-900 mb-4">
-                {t("timeline.title")}
-                </h2>
-                <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-                {t("timeline.subtitle")}
-                </p>
-            </SectionReveal>
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
-                <div className="lg:col-span-1">
-                    <div className="flex flex-col gap-4">
-                        {timelineSteps.map((step, index) => (
-                             <button key={index} onClick={() => setActiveStep(index)} className={`p-6 rounded-xl text-left transition-all duration-300 ${activeStep === index ? 'bg-primary/10 border-primary/50' : 'bg-white border-slate-200'} border`}>
-                                 <div className="flex items-center gap-4">
-                                    <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${activeStep === index ? 'bg-primary/20' : 'bg-slate-100'}`}>
-                                        <step.icon className={`w-5 h-5 ${activeStep === index ? 'text-primary' : 'text-slate-500'}`} />
-                                    </div>
-                                    <h3 className="text-lg font-bold text-slate-900">{step.title}</h3>
-                                 </div>
-                             </button>
-                        ))}
+      {/* ============================================
+          TIMELINE — 3 steps, each with a mockup
+          ============================================ */}
+      <section className="relative bg-slate-50 py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="mb-16 text-center">
+            <h2 className="mb-4 text-3xl font-bold text-slate-900 sm:text-4xl">
+              {t("timeline.title")}
+            </h2>
+            <p className="mx-auto max-w-3xl text-xl text-slate-600">{t("timeline.subtitle")}</p>
+          </SectionReveal>
+
+          <div className="grid grid-cols-1 gap-12 lg:grid-cols-3">
+            {/* Step selector */}
+            <div className="lg:col-span-1">
+              <div className="flex flex-col gap-4">
+                {timelineSteps.map((step, index) => (
+                  <button
+                    key={index}
+                    onClick={() => setActiveStep(index)}
+                    className={`rounded-xl border p-6 text-left transition-all duration-300 ${
+                      activeStep === index
+                        ? "border-primary/50 bg-primary/10"
+                        : "border-slate-200 bg-white"
+                    }`}
+                  >
+                    <div className="flex items-center gap-4">
+                      <div
+                        className={`flex h-10 w-10 items-center justify-center rounded-lg ${
+                          activeStep === index ? "bg-primary/20" : "bg-slate-100"
+                        }`}
+                      >
+                        <step.icon
+                          className={`h-5 w-5 ${
+                            activeStep === index ? "text-primary" : "text-slate-500"
+                          }`}
+                        />
+                      </div>
+                      <h3 className="text-lg font-bold text-slate-900">{step.title}</h3>
                     </div>
-                </div>
-                <div className="lg:col-span-2">
-                    <AnimatePresence mode="wait">
-                        <motion.div
-                            key={activeStep}
-                            initial={{ opacity: 0, y: 20 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            exit={{ opacity: 0, y: -20 }}
-                            transition={{ duration: 0.3 }}
-                            className="bg-white rounded-2xl border border-slate-200 p-8"
-                        >
-                            <div className="aspect-[16/9] rounded-lg overflow-hidden mb-6 bg-slate-900">
-                                <video
-                                    key={timelineSteps[activeStep].video}
-                                    className="w-full h-full object-cover"
-                                    autoPlay
-                                    loop
-                                    muted
-                                    playsInline
-                                >
-                                    <source src={timelineSteps[activeStep].video} type="video/mp4" />
-                                </video>
-                            </div>
-                            <h3 className="text-2xl font-bold text-slate-900 mb-4">{timelineSteps[activeStep].title}</h3>
-                            <p className="text-slate-600 mb-6">{timelineSteps[activeStep].description}</p>
-                             <div className="flex flex-wrap gap-2">
-                                {timelineSteps[activeStep].tags.map(tag => (
-                                     <span key={tag} className="text-xs bg-primary/10 text-primary/80 px-2 py-1 rounded">
-                                        {tag}
-                                    </span>
-                                ))}
-                            </div>
-                        </motion.div>
-                    </AnimatePresence>
-                </div>
+                  </button>
+                ))}
+              </div>
             </div>
+
+            {/* Step detail */}
+            <div className="lg:col-span-2">
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={activeStep}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -20 }}
+                  transition={{ duration: 0.3 }}
+                  className="rounded-2xl border border-slate-200 bg-white p-8"
+                >
+                  <div className="mb-8 flex min-h-[380px] items-center justify-center rounded-xl bg-gradient-to-br from-slate-100 to-slate-50 p-8">
+                    {stepMocks[activeStep]}
+                  </div>
+                  <h3 className="mb-4 text-2xl font-bold text-slate-900">
+                    {timelineSteps[activeStep].title}
+                  </h3>
+                  <p className="mb-6 text-slate-600">{timelineSteps[activeStep].description}</p>
+                  <div className="flex flex-wrap gap-2">
+                    {timelineSteps[activeStep].tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="rounded bg-primary/10 px-2 py-1 text-xs text-primary/80"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </motion.div>
+              </AnimatePresence>
+            </div>
+          </div>
         </div>
         <CurveDivider fillColor="fill-white" />
       </section>
 
-      {/* What You Get & Signals Grid Section */}
-      <section className="relative py-20 sm:py-24 bg-white">
-        <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-6">
-          <SectionReveal className="text-center mb-16">
-            <h2 className="text-3xl sm:text-4xl font-bold text-slate-900 mb-4">
-              {t("features.title")}
+      {/* ============================================
+          HIRING-MANAGER VIEW — pick the right hire
+          ============================================ */}
+      <section className="relative bg-white py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="mb-14 text-center">
+            <p className="mb-3 text-[10px] font-black uppercase tracking-[0.3em] text-primary">
+              {t("hiringManagers.badge")}
+            </p>
+            <h2 className="mb-4 text-3xl font-bold text-slate-900 sm:text-4xl">
+              {t("hiringManagers.title")}
             </h2>
-            <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-              {t("features.subtitle")}
+            <p className="mx-auto max-w-3xl text-xl text-slate-600">
+              {t("hiringManagers.subtitle")}
             </p>
           </SectionReveal>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto">
-              <FeatureCard icon={BarChart3} title={t("features.scorecard.title")} text={t("features.scorecard.text")} iconColor="blue" />
-              <FeatureCard icon={MessageSquare} title={t("features.transcripts.title")} text={t("features.transcripts.text")} iconColor="purple" />
-              <FeatureCard icon={Video} title={t("features.recording.title")} text={t("features.recording.text")} iconColor="emerald" />
-              <FeatureCard icon={Brain} title={t("features.aiUsage.title")} text={t("features.aiUsage.text")} iconColor="amber" />
-              <FeatureCard icon={CheckCircle} title={t("features.feedback.title")} text={t("features.feedback.text")} iconColor="rose" />
-              <FeatureCard icon={Users} title={t("features.communication.title")} text={t("features.communication.text")} iconColor="indigo" />
+
+          <SectionReveal className="mx-auto max-w-6xl">
+            <div className="rounded-3xl bg-gradient-to-br from-slate-100 to-slate-50 p-6 ring-1 ring-slate-200 sm:p-10">
+              <HiringManagerMock />
+            </div>
+          </SectionReveal>
+
+          <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-3">
+            {[
+              { title: t("hiringManagers.card1.title"), desc: t("hiringManagers.card1.desc") },
+              { title: t("hiringManagers.card2.title"), desc: t("hiringManagers.card2.desc") },
+              { title: t("hiringManagers.card3.title"), desc: t("hiringManagers.card3.desc") },
+            ].map((v, i) => (
+              <motion.div
+                key={v.title}
+                initial={{ opacity: 0, y: 12 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: i * 0.1 }}
+                className="rounded-2xl border border-slate-200 bg-white p-6"
+              >
+                <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-lg font-black text-primary">
+                  {i + 1}
+                </div>
+                <h3 className="mb-2 text-lg font-bold text-slate-900">{v.title}</h3>
+                <p className="text-sm leading-relaxed text-slate-600">{v.desc}</p>
+              </motion.div>
+            ))}
           </div>
         </div>
         <CurveDivider fillColor="fill-slate-50" />
       </section>
 
-      {/* Comparison Section */}
-      <section className="relative py-20 sm:py-24 bg-slate-50">
-        <div className="max-w-5xl mx-auto px-6 sm:px-8 lg:px-6">
-             <SectionReveal className="text-center mb-16">
-                <h2 className="text-3xl sm:text-4xl font-bold text-slate-900 mb-4">
-                {t("comparison.title")}
-                </h2>
-            </SectionReveal>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                {/* The Old Way */}
-                <motion.div initial={{ opacity: 0, x: -30 }} whileInView={{ opacity: 1, x: 0 }} viewport={{ once: true }}>
-                    <h2 className="text-2xl font-bold text-red-600 mb-6 text-center">{t("comparison.oldWayLabel")}</h2>
-                    <div className="space-y-6">
-                        {comparisonData.map((item, index) => (
-                            <div key={index} className="bg-white border border-slate-200 rounded-xl p-6">
-                                <h3 className="font-bold text-slate-900 mb-2">{item.feature}</h3>
-                                <div className="flex items-start gap-3">
-                                    <XCircle className="w-5 h-5 text-red-500 mt-1 flex-shrink-0" />
-                                    <p className="text-slate-600 text-sm">{item.oldWay}</p>
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                </motion.div>
-
-                {/* The Skillvee Way */}
-                <motion.div initial={{ opacity: 0, x: 30 }} whileInView={{ opacity: 1, x: 0 }} viewport={{ once: true }}>
-                    <h2 className="text-2xl font-bold text-emerald-600 mb-6 text-center">{t("comparison.skillveeWayLabel")}</h2>
-                     <div className="space-y-6">
-                        {comparisonData.map((item, index) => (
-                            <div key={index} className="bg-white border border-slate-200 rounded-xl p-6">
-                                <h3 className="font-bold text-slate-900 mb-2">{item.feature}</h3>
-                                <div className="flex items-start gap-3">
-                                    <CheckCircle className="w-5 h-5 text-emerald-500 mt-1 flex-shrink-0" />
-                                    <p className="text-slate-600 text-sm">{item.skillveeWay}</p>
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                </motion.div>
-            </div>
+      {/* ============================================
+          FEATURES GRID
+          ============================================ */}
+      <section className="relative bg-slate-50 py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="mb-16 text-center">
+            <h2 className="mb-4 text-3xl font-bold text-slate-900 sm:text-4xl">
+              {t("features.title")}
+            </h2>
+            <p className="mx-auto max-w-3xl text-xl text-slate-600">{t("features.subtitle")}</p>
+          </SectionReveal>
+          <div className="mx-auto grid max-w-6xl grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+            <FeatureCard
+              icon={BarChart3}
+              title={t("features.scorecard.title")}
+              text={t("features.scorecard.text")}
+              iconBg="bg-blue-500/10"
+              iconColor="text-blue-600"
+            />
+            <FeatureCard
+              icon={MessageSquare}
+              title={t("features.transcripts.title")}
+              text={t("features.transcripts.text")}
+              iconBg="bg-purple-500/10"
+              iconColor="text-purple-600"
+            />
+            <FeatureCard
+              icon={Video}
+              title={t("features.recording.title")}
+              text={t("features.recording.text")}
+              iconBg="bg-emerald-500/10"
+              iconColor="text-emerald-600"
+            />
+            <FeatureCard
+              icon={Brain}
+              title={t("features.aiUsage.title")}
+              text={t("features.aiUsage.text")}
+              iconBg="bg-amber-500/10"
+              iconColor="text-amber-600"
+            />
+            <FeatureCard
+              icon={CheckCircle2}
+              title={t("features.feedback.title")}
+              text={t("features.feedback.text")}
+              iconBg="bg-rose-500/10"
+              iconColor="text-rose-600"
+            />
+            <FeatureCard
+              icon={Users}
+              title={t("features.communication.title")}
+              text={t("features.communication.text")}
+              iconBg="bg-indigo-500/10"
+              iconColor="text-indigo-600"
+            />
+          </div>
         </div>
+        <CurveDivider fillColor="fill-white" />
       </section>
 
-      {/* Security & Enterprise Section */}
-      <section className="relative py-20 sm:py-24 bg-slate-900">
-        <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-6">
-          <SectionReveal className="text-center mb-16">
-            <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
-              {t("security.title")}
+      {/* ============================================
+          COMPARISON
+          ============================================ */}
+      <section className="relative bg-white py-20 sm:py-24">
+        <div className="mx-auto max-w-5xl px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="mb-16 text-center">
+            <h2 className="mb-4 text-3xl font-bold text-slate-900 sm:text-4xl">
+              {t("comparison.title")}
             </h2>
-            <p className="text-xl text-slate-400 max-w-3xl mx-auto">
-              {t("security.subtitle")}
+          </SectionReveal>
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+            <motion.div
+              initial={{ opacity: 0, x: -30 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              viewport={{ once: true }}
+            >
+              <h3 className="mb-6 text-center text-2xl font-bold text-red-600">
+                {t("comparison.oldWayLabel")}
+              </h3>
+              <div className="space-y-6">
+                {comparisonData.map((item, index) => (
+                  <div
+                    key={index}
+                    className="rounded-xl border border-slate-200 bg-slate-50 p-6"
+                  >
+                    <h3 className="mb-2 font-bold text-slate-900">{item.feature}</h3>
+                    <div className="flex items-start gap-3">
+                      <XCircle className="mt-1 h-5 w-5 flex-shrink-0 text-red-500" />
+                      <p className="text-sm text-slate-600">{item.oldWay}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, x: 30 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              viewport={{ once: true }}
+            >
+              <h3 className="mb-6 text-center text-2xl font-bold text-emerald-600">
+                {t("comparison.skillveeWayLabel")}
+              </h3>
+              <div className="space-y-6">
+                {comparisonData.map((item, index) => (
+                  <div
+                    key={index}
+                    className="rounded-xl border border-slate-200 bg-slate-50 p-6"
+                  >
+                    <h3 className="mb-2 font-bold text-slate-900">{item.feature}</h3>
+                    <div className="flex items-start gap-3">
+                      <CheckCircle className="mt-1 h-5 w-5 flex-shrink-0 text-emerald-500" />
+                      <p className="text-sm text-slate-600">{item.skillveeWay}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </motion.div>
+          </div>
+        </div>
+        <CurveDivider fillColor="fill-slate-50" />
+      </section>
+
+      {/* ============================================
+          FITS YOUR WORKFLOW — setup speed + ATS logos
+          ============================================ */}
+      <section className="relative bg-slate-50 py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="mb-14 text-center">
+            <p className="mb-3 text-[10px] font-black uppercase tracking-[0.3em] text-primary">
+              {t("workflow.badge")}
+            </p>
+            <h2 className="mb-4 text-3xl font-bold text-slate-900 sm:text-4xl">
+              {t("workflow.title")}
+            </h2>
+            <p className="mx-auto max-w-3xl text-xl text-slate-600">
+              {t("workflow.subtitle")}
             </p>
           </SectionReveal>
 
+          {/* 3-step setup flow */}
+          <div className="mx-auto mb-20 grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-3">
+            {[
+              {
+                step: "1",
+                title: t("workflow.step1.title"),
+                desc: t("workflow.step1.desc"),
+                visual: (
+                  <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+                    <div className="mb-2 flex items-center gap-1.5">
+                      <div className="h-1.5 w-1.5 rounded-full bg-slate-300" />
+                      <span className="text-[9px] font-semibold text-slate-500">{t("workflow.step1.label")}</span>
+                    </div>
+                    <div className="space-y-1.5">
+                      <div className="h-1.5 w-full rounded bg-slate-200" />
+                      <div className="h-1.5 w-11/12 rounded bg-slate-200" />
+                      <div className="h-1.5 w-4/5 rounded bg-slate-200" />
+                      <div className="h-1.5 w-3/4 rounded bg-slate-200" />
+                    </div>
+                  </div>
+                ),
+              },
+              {
+                step: "2",
+                title: t("workflow.step2.title"),
+                desc: t("workflow.step2.desc"),
+                visual: (
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 p-2">
+                      <div className="h-6 w-6 flex-shrink-0 rounded-lg bg-emerald-500 text-[10px] font-bold text-white flex items-center justify-center">S</div>
+                      <div className="flex-1">
+                        <div className="text-[10px] font-semibold text-slate-900">{t("workflow.step2.persona1")}</div>
+                      </div>
+                      <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+                    </div>
+                    <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 p-2">
+                      <div className="h-6 w-6 flex-shrink-0 rounded-lg bg-purple-500 text-[10px] font-bold text-white flex items-center justify-center">D</div>
+                      <div className="flex-1">
+                        <div className="text-[10px] font-semibold text-slate-900">{t("workflow.step2.persona2")}</div>
+                      </div>
+                      <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+                    </div>
+                    <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 p-2">
+                      <div className="h-6 w-6 flex-shrink-0 rounded-lg bg-amber-500 text-[10px] font-bold text-white flex items-center justify-center">T</div>
+                      <div className="flex-1">
+                        <div className="text-[10px] font-semibold text-slate-900">{t("workflow.step2.persona3")}</div>
+                      </div>
+                      <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+                    </div>
+                  </div>
+                ),
+              },
+              {
+                step: "3",
+                title: t("workflow.step3.title"),
+                desc: t("workflow.step3.desc"),
+                visual: (
+                  <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+                    <div className="mb-2 flex items-center justify-between">
+                      <span className="text-[9px] font-semibold text-slate-500">{t("workflow.step3.linkLabel")}</span>
+                      <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[9px] font-bold text-emerald-700">
+                        {t("workflow.step3.ready")}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1.5 rounded border border-slate-200 bg-white p-1.5">
+                      <Globe className="h-3 w-3 text-slate-400" />
+                      <span className="truncate font-mono text-[10px] text-slate-700">
+                        skillvee.com/s/a8f2-backend
+                      </span>
+                    </div>
+                    <div className="mt-2 flex justify-end">
+                      <div className="flex items-center gap-1 rounded bg-primary px-2 py-1 text-[10px] font-bold text-white">
+                        <Send className="h-2.5 w-2.5" /> {t("workflow.step3.copyLink")}
+                      </div>
+                    </div>
+                  </div>
+                ),
+              },
+            ].map((s, i) => (
+              <motion.div
+                key={s.step}
+                initial={{ opacity: 0, y: 16 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: i * 0.1 }}
+                className="relative rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+              >
+                <div className="mb-4 flex items-center gap-3">
+                  <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary text-base font-black text-white shadow-lg shadow-primary/20">
+                    {s.step}
+                  </div>
+                  <h3 className="text-lg font-bold text-slate-900">{s.title}</h3>
+                </div>
+                <div className="mb-4">{s.visual}</div>
+                <p className="text-sm leading-relaxed text-slate-600">{s.desc}</p>
+              </motion.div>
+            ))}
+          </div>
+
+          {/* ATS integrations */}
+          <SectionReveal className="mx-auto max-w-5xl">
+            <div className="rounded-2xl border border-slate-200 bg-white p-8 text-center shadow-sm">
+              <div className="mb-2 text-xs font-bold uppercase tracking-widest text-slate-500">
+                {t("ats.badge")}
+              </div>
+              <p className="mx-auto mb-6 max-w-xl text-sm text-slate-600">
+                {t("ats.description")}
+              </p>
+              <div className="flex flex-wrap items-center justify-center gap-x-8 gap-y-4">
+                {[
+                  "Greenhouse",
+                  "Lever",
+                  "Ashby",
+                  "Workday",
+                  "Rippling",
+                  "Teamtailor",
+                  "SmartRecruiters",
+                ].map((ats) => (
+                  <span
+                    key={ats}
+                    className="text-lg font-bold tracking-tight text-slate-400 transition-colors hover:text-slate-700"
+                  >
+                    {ats}
+                  </span>
+                ))}
+              </div>
+              <div className="mt-6 text-xs text-slate-500">
+                {t("ats.footer")}
+              </div>
+            </div>
+          </SectionReveal>
+        </div>
+      </section>
+
+      {/* ============================================
+          SECURITY
+          ============================================ */}
+      <section className="relative bg-slate-900 py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="mb-16 text-center">
+            <h2 className="mb-4 text-3xl font-bold text-white sm:text-4xl">
+              {t("security.title")}
+            </h2>
+            <p className="mx-auto max-w-3xl text-xl text-slate-400">{t("security.subtitle")}</p>
+          </SectionReveal>
+
           <SectionReveal>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
+            <div className="mx-auto grid max-w-5xl grid-cols-1 gap-8 md:grid-cols-3">
               <div className="text-center">
-                <div className="w-16 h-16 bg-blue-500/30 rounded-2xl flex items-center justify-center mx-auto mb-4">
-                  <Shield className="w-8 h-8 text-blue-400" />
+                <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-500/30">
+                  <Shield className="h-8 w-8 text-blue-400" />
                 </div>
-                <h3 className="text-lg font-bold text-white mb-2">{t("security.soc2.title")}</h3>
-                <p className="text-slate-400 text-sm">
-                  {t("security.soc2.description")}
-                </p>
+                <h3 className="mb-2 text-lg font-bold text-white">{t("security.soc2.title")}</h3>
+                <p className="text-sm text-slate-400">{t("security.soc2.description")}</p>
               </div>
 
               <div className="text-center">
-                <div className="w-16 h-16 bg-blue-500/30 rounded-2xl flex items-center justify-center mx-auto mb-4">
-                  <Lock className="w-8 h-8 text-blue-400" />
+                <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-500/30">
+                  <Lock className="h-8 w-8 text-blue-400" />
                 </div>
-                <h3 className="text-lg font-bold text-white mb-2">{t("security.gdpr.title")}</h3>
-                <p className="text-slate-400 text-sm">
-                  {t("security.gdpr.description")}
-                </p>
+                <h3 className="mb-2 text-lg font-bold text-white">{t("security.gdpr.title")}</h3>
+                <p className="text-sm text-slate-400">{t("security.gdpr.description")}</p>
               </div>
 
               <div className="text-center">
-                <div className="w-16 h-16 bg-blue-500/30 rounded-2xl flex items-center justify-center mx-auto mb-4">
-                  <Globe className="w-8 h-8 text-blue-400" />
+                <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-500/30">
+                  <Globe className="h-8 w-8 text-blue-400" />
                 </div>
-                <h3 className="text-lg font-bold text-white mb-2">{t("security.sso.title")}</h3>
-                <p className="text-slate-400 text-sm">
-                  {t("security.sso.description")}
-                </p>
+                <h3 className="mb-2 text-lg font-bold text-white">{t("security.sso.title")}</h3>
+                <p className="text-sm text-slate-400">{t("security.sso.description")}</p>
               </div>
             </div>
           </SectionReveal>
 
-          <SectionReveal className="text-center mt-12">
+          <SectionReveal className="mt-12 text-center">
             <Link href="/demo">
               <Button
                 variant="outline"
-                className="bg-transparent border-white/50 text-white hover:bg-white/10 hover:border-white"
+                className="border-white/50 bg-transparent text-white hover:border-white hover:bg-white/10"
               >
                 {t("security.contactCta")}
               </Button>
@@ -418,11 +1320,13 @@ export default function ProductPage() {
         </div>
       </section>
 
-      {/* Product FAQ */}
-      <section className="py-20 sm:py-24 bg-white">
-        <div className="max-w-4xl mx-auto px-6 sm:px-8 lg:px-6">
-          <SectionReveal className="text-center mb-12">
-            <h2 className="text-3xl sm:text-4xl font-bold text-slate-900 mb-4">
+      {/* ============================================
+          FAQ
+          ============================================ */}
+      <section className="bg-white py-20 sm:py-24">
+        <div className="mx-auto max-w-4xl px-6 sm:px-8 lg:px-6">
+          <SectionReveal className="mb-12 text-center">
+            <h2 className="mb-4 text-3xl font-bold text-slate-900 sm:text-4xl">
               {t("faq.title")}
             </h2>
           </SectionReveal>
@@ -430,40 +1334,40 @@ export default function ProductPage() {
         </div>
       </section>
 
-      {/* Final CTA */}
-      <section className="py-32 bg-[#020617] relative overflow-hidden">
+      {/* ============================================
+          FINAL CTA
+          ============================================ */}
+      <section className="relative overflow-hidden bg-[#020617] py-32">
         <motion.div
-          animate={{
-            scale: [1, 1.2, 1],
-            opacity: [0.2, 0.4, 0.2],
-          }}
+          animate={{ scale: [1, 1.2, 1], opacity: [0.2, 0.4, 0.2] }}
           transition={{ duration: 10, repeat: Infinity, ease: "easeInOut" }}
-          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-primary/20 rounded-full blur-[200px] pointer-events-none"
+          className="pointer-events-none absolute left-1/2 top-1/2 h-[800px] w-[800px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/20 blur-[200px]"
         />
 
-        <div className="relative z-10 max-w-4xl mx-auto px-6 text-center">
+        <div className="relative z-10 mx-auto max-w-4xl px-6 text-center">
           <motion.div
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
           >
-            <h2 className="text-4xl lg:text-6xl font-black text-white mb-6">
+            <h2 className="mb-6 text-4xl font-black text-white lg:text-6xl">
               {t("cta.title")}
               <br />
               <span className="text-primary">{t("cta.titleHighlight")}</span>
             </h2>
-            <p className="text-xl text-slate-400 mb-10 max-w-2xl mx-auto">
-              {t("cta.subtitle")}
-            </p>
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <p className="mx-auto mb-10 max-w-2xl text-xl text-slate-400">{t("cta.subtitle")}</p>
+            <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
               <Link href="/demo">
-                <Button className="h-14 px-10 rounded-full bg-white text-slate-900 font-bold text-lg shadow-xl hover:bg-slate-100 group">
+                <Button className="group h-14 rounded-full bg-white px-10 text-lg font-bold text-slate-900 shadow-xl hover:bg-slate-100">
                   {t("cta.requestDemo")}
-                  <ArrowRight className="ml-2 w-5 h-5 group-hover:translate-x-1 transition-transform" />
+                  <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
                 </Button>
               </Link>
               <Link href="/demo#sample">
-                <Button variant="ghost" className="h-14 px-8 rounded-full text-white hover:bg-white/10 font-semibold">
+                <Button
+                  variant="ghost"
+                  className="h-14 rounded-full border border-white/30 bg-transparent px-8 font-semibold text-white hover:border-white/50 hover:bg-white/10 hover:text-white"
+                >
                   {t("cta.trySample")}
                 </Button>
               </Link>


### PR DESCRIPTION
## Summary
- **Product page redesign** (`/product`): much larger overhaul with new sections — interactive Slack-style demo, full simulation phase walkthrough, expanded social proof and security copy.
- **New `/brochure` route**: single-scroll hiring-manager pitch derived from the product page content, plus a printable companion `brochure.md` at the repo root for sharing offline.
- Tighten hero spacing on the locale home page and rework the `presentation-v2` cover slide copy + logo treatment.

Marketing-only changes — no schema, API, or candidate-flow code touched.

## Test plan
- [ ] `npm run dev` and visually verify `/`, `/product`, `/brochure`, `/presentation-v2` at desktop and mobile widths
- [ ] `npm run check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)